### PR TITLE
feat!: make `sarif` input the SARIF output path and always print the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,12 @@ steps:
 
 - `inputFile`: _(required)_ The path to the input file, i.e. the file containing the output of the linter.
 
-- `sarif`: True by default - generates a SARIF file as an output. If set to false, the action will not generate a SARIF file.
+- `sarif`: The path to the output SARIF file this action should generate. If not specified, the action will generate a `sarif.json` file in the root of the
+  repository. If set to an empty string, the action will not write a SARIF file. The SARIF is always generated and printed to the workflow log.
 
 - `comment`: Set to true to comment on the PR with the issues. If set to false or ommitted, the action will not comment on the PR.
 
 - `summary`: True by default - generates a markdown summary for the job. If set to false, the action will not generate a markdown summary.
-
-- `outputFile`: The path to the output SARIF file this action should generate. If not specified, the action will generate a `sarif.json` file in the root of
-  the repository.
 
 - `toolName`: _(required)_ The `tool name` that will be written in the SARIF output. This is used by both code scanning and auto-pr-commenting to resolve fixed
   issues.

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,9 @@ inputs:
     description: 'Path to the file with the linter output'
     required: true
   sarif:
-    description: 'Should the action create a SARIF file'
+    description: 'Path to the SARIF file this action will generate. Set to an empty string to not write a file'
     required: false
-    default: 'true'
+    default: 'sarif.json'
   comment:
     description: 'Should the action comment on the PR'
     required: false
@@ -17,10 +17,6 @@ inputs:
     description: 'Should the action create a markdown summary'
     required: false
     default: 'true'
-  outputFile:
-    description: 'Path to the SARIF file this action will generate'
-    required: false
-    default: 'sarif.json'
   toolName:
     description: 'Name of the tool to be written in the SARIF'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -32100,10 +32100,9 @@ const bugalint_1 = __nccwpck_require__(8983);
 async function run() {
     try {
         const inputFile = (0, core_1.getInput)('inputFile');
-        const sarif = (0, core_1.getBooleanInput)('sarif');
+        const sarif = (0, core_1.getInput)('sarif');
         const comment = (0, core_1.getBooleanInput)('comment');
         const summary = (0, core_1.getBooleanInput)('summary');
-        const outputFile = (0, core_1.getInput)('outputFile');
         const toolName = (0, core_1.getInput)('toolName');
         const inputFormat = (0, core_1.getInput)('inputFormat');
         const inputRegex = (0, core_1.getInput)('inputRegex');
@@ -32115,10 +32114,10 @@ async function run() {
             : (0, bugalint_1.getKnownParser)(inputFormat);
         const input = (0, fs_1.readFileSync)(inputFile, 'utf-8').replace(/\r/g, '');
         (0, core_1.debug)(`input: ${input}`);
-        if (sarif) {
-            const output = (0, bugalint_1.generateSarif)(parser(input), toolName, analysisPath);
-            (0, core_1.debug)(`SARIF output: ${JSON.stringify(output, null, 2)}`);
-            (0, fs_1.writeFileSync)(outputFile, JSON.stringify(output));
+        const output = (0, bugalint_1.generateSarif)(parser(input), toolName, analysisPath);
+        (0, core_1.info)(`SARIF output: ${JSON.stringify(output, null, 2)}`);
+        if (sarif !== '') {
+            (0, fs_1.writeFileSync)(sarif, JSON.stringify(output));
         }
         if (comment) {
             const prNumber = github_1.context.payload.pull_request?.number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,15 @@
 import { readFileSync, writeFileSync } from 'fs'
 import type { Result } from 'sarif'
 import { context } from '@actions/github'
-import { getInput, getBooleanInput, debug, setFailed } from '@actions/core'
+import { getInput, getBooleanInput, debug, info, setFailed } from '@actions/core'
 import { generateSarif, getKnownParser, getRegexParser, addComments, createSummary, type Parser } from '../src/bugalint'
 
 export async function run(): Promise<void> {
   try {
     const inputFile: string = getInput('inputFile')
-    const sarif: boolean = getBooleanInput('sarif')
+    const sarif: string = getInput('sarif')
     const comment: boolean = getBooleanInput('comment')
     const summary: boolean = getBooleanInput('summary')
-    const outputFile: string = getInput('outputFile')
     const toolName: string = getInput('toolName')
     const inputFormat: string = getInput('inputFormat')
     const inputRegex: string = getInput('inputRegex')
@@ -24,10 +23,10 @@ export async function run(): Promise<void> {
         : getKnownParser(inputFormat)
     const input = readFileSync(inputFile, 'utf-8').replace(/\r/g, '')
     debug(`input: ${input}`)
-    if (sarif) {
-      const output = generateSarif(parser(input), toolName, analysisPath)
-      debug(`SARIF output: ${JSON.stringify(output, null, 2)}`)
-      writeFileSync(outputFile, JSON.stringify(output))
+    const output = generateSarif(parser(input), toolName, analysisPath)
+    info(`SARIF output: ${JSON.stringify(output, null, 2)}`)
+    if (sarif !== '') {
+      writeFileSync(sarif, JSON.stringify(output))
     }
     if (comment) {
       const prNumber = context.payload.pull_request?.number


### PR DESCRIPTION
## What

- The `sarif` input is now the **path** of the SARIF file to write (default `sarif.json`), replacing the old boolean `sarif` input and the separate `outputFile` input.
- The SARIF log is now **always generated and printed** to the workflow log as a regular log line (`info`), instead of a `debug` message. Setting `sarif` to an empty string skips writing the file (the log is still printed).

## Breaking change

`sarif: 'true'` / `sarif: 'false'` no longer work — use `sarif: <path>` (or `''` to skip the file), and remove `outputFile`.

## Testing

- The existing CI `gha` matrix exercises the new behavior end-to-end: the action now writes to the default `sarif.json` path without any `outputFile` input, and the json-diff against the fixtures verifies the content.
- Existing conversion tests are unaffected.