### PR TITLE
feat!: fail the step when the linter finds issues

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -81,19 +81,25 @@ jobs:
           - {linter: 'ghalint', format: 'ghalint', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'sarif', format: 'sarif', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'flake8subpath', format: 'flake8', regex: '', levelMap: '', analysisPath: 'A\B'}
+          - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', outcome: 'success'}
+          - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'noissues-nofail'}
+          - {linter: 'pylint', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'pylint-nofail'}
+          - {linter: 'pylint', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', failOnlyNew: 'true', outcome: 'success', name: 'pylint-onlynew'}
           - linter: 'custom'
             format: ''
             # yamllint disable-line rule:line-length
             regex: '^(?<path>[^-\n]+)(?:-(?<line>\d+))?(?:-(?<col>\d+))?(?:-(?<eline>\d+))?(?:-(?<ecol>\d+))? (?<level>[^:\s]+):(?<id>[^:\s]+):(?<sym>[^:\s]+) (?<msg>.+)$'
             levelMap: '{ "err": "error", "warn": "warning", "info": "note" }'
             analysisPath: '.'
-    name: GitHub Action (${{ matrix.run.linter }})
+    name: GitHub Action (${{ matrix.run.name || matrix.run.linter }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Dependencies
         run: npm install -g json-diff
       - name: Run Action
+        id: run
+        continue-on-error: true
         uses: ./
         with:
           inputFile: '__tests__/${{ matrix.run.linter }}.input.txt'
@@ -102,6 +108,15 @@ jobs:
           inputRegex: ${{ matrix.run.regex }}
           levelMap: ${{ matrix.run.levelMap }}
           analysisPath: ${{ matrix.run.analysisPath }}
+          fail: ${{ matrix.run.fail || 'true' }}
+          failOnlyNew: ${{ matrix.run.failOnlyNew || 'false' }}
+      - name: Test Outcome
+        run: |
+          if [ "${{ steps.run.outcome }}" != "${{ matrix.run.outcome || 'failure' }}" ];
+          then
+            echo "Expected the action to end with ${{ matrix.run.outcome || 'failure' }} but it ended with ${{ steps.run.outcome }}"
+            exit 1
+          fi
       - name: Create Diff
         run: json-diff "__tests__/${{ matrix.run.linter }}.output.json" "sarif.json" | tee diff.txt
       - name: Test Output

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ steps:
 
 - `summary`: True by default - generates a markdown summary for the job. If set to false, the action will not generate a markdown summary.
 
+- `fail`: True by default - fails the step if the linter found any issues. If set to false, the action will not fail the step.
+
+- `failOnlyNew`: Set to true to fail only on issues found on lines added in the pull request (requires running on a pull request). If set to false or
+  omitted, the action will fail on any issue. Ignored if `fail` is set to false.
+
 - `toolName`: _(required)_ The `tool name` that will be written in the SARIF output. This is used by both code scanning and auto-pr-commenting to resolve fixed
   issues.
 

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -1,6 +1,6 @@
 import '@microsoft/jest-sarif'
 import { readFileSync } from 'fs'
-import { generateSarif, getKnownParser, getRegexParser, _testExports, type Parser } from '../src/bugalint'
+import { generateSarif, getKnownParser, getRegexParser, parseAddedLines, isNewIssue, failOnIssues, _testExports, type Parser } from '../src/bugalint'
 
 describe('fullConversion', () => {
   it.each([
@@ -12,6 +12,7 @@ describe('fullConversion', () => {
     ['ghalint', getKnownParser('ghalint'), '.'],
     ['sarif', getKnownParser('sarif'), '.'],
     ['flake8subpath', getKnownParser('flake8'), 'A\\B'],
+    ['noissues', getKnownParser('flake8'), '.'],
     [
       'custom',
       getRegexParser(
@@ -26,6 +27,67 @@ describe('fullConversion', () => {
     const result = generateSarif(parser(input), 'test', analysisPath)
     expect(result).toBeValidSarifLog()
     expect(JSON.parse(JSON.stringify(result))).toStrictEqual(JSON.parse(output))
+  })
+})
+
+describe('newIssues', () => {
+  const diff = `diff --git a/A/B/test.py b/A/B/test.py
+index 1111111..2222222 100644
+--- a/A/B/test.py
++++ b/A/B/test.py
+@@ -1,2 +1,3 @@
+ import os
++import sys
++x = 1
+`
+  const addedLines = parseAddedLines(diff)
+
+  it('collects added line numbers per file', () => {
+    expect(addedLines).toStrictEqual({ 'A/B/test.py': { 2: true, 3: true } })
+  })
+
+  it('accepts issues contained in added lines', () => {
+    expect(isNewIssue({ path: 'A/B/test.py', line: 2 }, addedLines, '.')).toBe(true)
+    expect(isNewIssue({ path: 'A/B/test.py', line: 2, eline: 3 }, addedLines, '.')).toBe(true)
+    expect(isNewIssue({ path: 'test.py', line: 3 }, addedLines, 'A\\B')).toBe(true)
+  })
+
+  it('rejects issues not fully contained in added lines', () => {
+    expect(isNewIssue({ path: 'A/B/test.py', line: 1 }, addedLines, '.')).toBe(false)
+    expect(isNewIssue({ path: 'A/B/test.py', line: 1, eline: 2 }, addedLines, '.')).toBe(false)
+    expect(isNewIssue({ path: 'A/B/other.py', line: 2 }, addedLines, '.')).toBe(false)
+    expect(isNewIssue({ line: 2 }, addedLines, '.')).toBe(false)
+    expect(isNewIssue({ path: 'A/B/test.py' }, addedLines, '.')).toBe(false)
+  })
+
+  describe('failOnIssues', () => {
+    it('does nothing when no issues are found', () => {
+      expect(() => {
+        failOnIssues([], 'test', '.')
+      }).not.toThrow()
+    })
+
+    it('throws when issues are found', () => {
+      expect(() => {
+        failOnIssues([{ path: 'a.py', line: 1 }, { msg: 'x' }], 'test', '.')
+      }).toThrow('test found 2 issues')
+    })
+
+    it('throws only on new issues when a diff is given', () => {
+      const issues = [
+        { path: 'A/B/test.py', line: 1 },
+        { path: 'A/B/test.py', line: 2 }
+      ]
+      expect(() => {
+        failOnIssues(issues, 'test', '.', diff)
+      }).toThrow('test found 1 issues')
+    })
+
+    it('does nothing when a diff is given and all issues are old', () => {
+      expect(() => {
+        failOnIssues([{ path: 'A/B/test.py', line: 1 }], 'test', '.', diff)
+      }).not.toThrow()
+    })
   })
 })
 

--- a/__tests__/noissues.output.json
+++ b/__tests__/noissues.output.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [{ "tool": { "driver": { "name": "test", "rules": [] } }, "results": [] }]
+}

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Should the action create a markdown summary'
     required: false
     default: 'true'
+  fail:
+    description: 'Should the action fail the step if issues are found'
+    required: false
+    default: 'true'
+  failOnlyNew:
+    description: 'Should the action fail only on issues found on lines added in the pull request'
+    required: false
+    default: 'false'
   toolName:
     description: 'Name of the tool to be written in the SARIF'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -29937,6 +29937,10 @@ exports.generateSarif = generateSarif;
 exports.getKnownParser = getKnownParser;
 exports.getRegexParser = getRegexParser;
 exports.addComments = addComments;
+exports.getPrDiff = getPrDiff;
+exports.parseAddedLines = parseAddedLines;
+exports.isNewIssue = isNewIssue;
+exports.failOnIssues = failOnIssues;
 exports.createSummary = createSummary;
 const github_1 = __nccwpck_require__(3228);
 const core_1 = __nccwpck_require__(7484);
@@ -30069,7 +30073,7 @@ function getKnownParser(identifier) {
 function getRegexParser(regex, levelMap) {
     return (input) => parseRegex(input, regex, levelMap);
 }
-async function addComments(issues, githubToken, identifier, owner, repo, prNumber, analysisPath) {
+async function addComments(issues, prDiff, githubToken, identifier, owner, repo, prNumber, analysisPath) {
     /* eslint camelcase: ["error", {allow: ['^pull_number$', '^comment_id$', '^start_side$', '^start_line$']}] */
     const octokit = (0, github_1.getOctokit)(githubToken);
     (0, core_1.debug)('Deleting old comments');
@@ -30082,40 +30086,12 @@ async function addComments(issues, githubToken, identifier, owner, repo, prNumbe
             }
         }
     }
-    const prDiff = (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data;
-    const linesSet = {};
-    for (const file of (0, parse_diff_1.default)(prDiff)) {
-        if (file.to == null) {
-            continue;
-        }
-        (0, core_1.debug)(`PR file diff: ${file.to} (${file.chunks.length} chunks)`);
-        linesSet[file.to] = {};
-        for (const chunk of file.chunks) {
-            for (const change of chunk.changes) {
-                if (change.type === 'add') {
-                    linesSet[file.to][change?.ln] = true;
-                }
-            }
-        }
-    }
-    (0, core_1.debug)(`linesSet: ${JSON.stringify(linesSet)}`);
+    const addedLines = parseAddedLines(prDiff);
     const comments = [];
     for (const issue of issues) {
         (0, core_1.debug)(`Processing issue on ${issue.path}:${issue.line}`);
-        if (issue.path == null || issue.line == null) {
-            continue;
-        }
-        const normalized = normalizePath(issue.path, analysisPath);
-        (0, core_1.debug)(`Normalized path: ${normalized}`);
-        if ((() => {
-            for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
-                if (!linesSet?.[normalized]?.[line]) {
-                    return true;
-                }
-            }
-            return false;
-        })()) {
-            (0, core_1.debug)(`Skipping issue on ${normalized}:${issue.line} because it's not in the PR diff`);
+        if (!isNewIssue(issue, addedLines, analysisPath)) {
+            (0, core_1.debug)(`Skipping issue on ${issue.path}:${issue.line} because it's not in the PR diff`);
             continue;
         }
         if (comments.length >= 50) {
@@ -30124,7 +30100,7 @@ async function addComments(issues, githubToken, identifier, owner, repo, prNumbe
         }
         const endLine = issue.eline ?? issue.line;
         const args = {
-            path: normalized,
+            path: normalizePath(issue.path, analysisPath),
             side: 'RIGHT',
             start_side: 'RIGHT',
             line: endLine,
@@ -30141,6 +30117,51 @@ async function addComments(issues, githubToken, identifier, owner, repo, prNumbe
     (0, core_1.debug)('Sending comments');
     await octokit.rest.pulls.createReview({ owner, repo, pull_number: prNumber, event: 'COMMENT', comments });
     (0, core_1.debug)('Sent comments');
+}
+async function getPrDiff(githubToken, owner, repo, prNumber) {
+    const octokit = (0, github_1.getOctokit)(githubToken);
+    return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data;
+}
+function parseAddedLines(diff) {
+    const addedLines = {};
+    for (const file of (0, parse_diff_1.default)(diff)) {
+        if (file.to == null) {
+            continue;
+        }
+        (0, core_1.debug)(`PR file diff: ${file.to} (${file.chunks.length} chunks)`);
+        addedLines[file.to] = {};
+        for (const chunk of file.chunks) {
+            for (const change of chunk.changes) {
+                if (change.type === 'add') {
+                    addedLines[file.to][change?.ln] = true;
+                }
+            }
+        }
+    }
+    (0, core_1.debug)(`addedLines: ${JSON.stringify(addedLines)}`);
+    return addedLines;
+}
+function isNewIssue(issue, addedLines, analysisPath) {
+    if (issue.path == null || issue.line == null) {
+        return false;
+    }
+    const normalized = normalizePath(issue.path, analysisPath);
+    for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
+        if (!addedLines?.[normalized]?.[line]) {
+            return false;
+        }
+    }
+    return true;
+}
+function failOnIssues(issues, toolName, analysisPath, prDiff) {
+    let failing = [...issues];
+    if (prDiff != null) {
+        const addedLines = parseAddedLines(prDiff);
+        failing = failing.filter((issue) => isNewIssue(issue, addedLines, analysisPath));
+    }
+    if (failing.length > 0) {
+        throw new Error(`${toolName} found ${failing.length} issues`);
+    }
 }
 async function createSummary(issues, identifier, analysisPath) {
     const table = [
@@ -32103,6 +32124,8 @@ async function run() {
         const sarif = (0, core_1.getInput)('sarif');
         const comment = (0, core_1.getBooleanInput)('comment');
         const summary = (0, core_1.getBooleanInput)('summary');
+        const fail = (0, core_1.getBooleanInput)('fail');
+        const failOnlyNew = (0, core_1.getBooleanInput)('failOnlyNew');
         const toolName = (0, core_1.getInput)('toolName');
         const inputFormat = (0, core_1.getInput)('inputFormat');
         const inputRegex = (0, core_1.getInput)('inputRegex');
@@ -32119,15 +32142,22 @@ async function run() {
         if (sarif !== '') {
             (0, fs_1.writeFileSync)(sarif, JSON.stringify(output));
         }
-        if (comment) {
+        let prDiff;
+        if (comment || (fail && failOnlyNew)) {
             const prNumber = github_1.context.payload.pull_request?.number;
             if (prNumber == null) {
                 throw new Error('No pull request number found.');
             }
-            await (0, bugalint_1.addComments)(parser(input), githubToken, toolName, github_1.context.repo.owner, github_1.context.repo.repo, prNumber, analysisPath);
+            prDiff = await (0, bugalint_1.getPrDiff)(githubToken, github_1.context.repo.owner, github_1.context.repo.repo, prNumber);
+            if (comment) {
+                await (0, bugalint_1.addComments)(parser(input), prDiff, githubToken, toolName, github_1.context.repo.owner, github_1.context.repo.repo, prNumber, analysisPath);
+            }
         }
         if (summary) {
             await (0, bugalint_1.createSummary)(parser(input), toolName, analysisPath);
+        }
+        if (fail) {
+            (0, bugalint_1.failOnIssues)(parser(input), toolName, analysisPath, failOnlyNew ? prDiff : undefined);
         }
     }
     catch (error) {

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -163,6 +163,7 @@ export function getRegexParser(regex: RegExp, levelMap?: Record<string, Result.l
 
 export async function addComments(
   issues: Iterable<Issue>,
+  prDiff: string,
   githubToken: string,
   identifier: string,
   owner: string,
@@ -184,45 +185,13 @@ export async function addComments(
     }
   }
 
-  const prDiff = (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data as unknown as string
-  const linesSet: Record<string, Record<number, boolean>> = {}
-  for (const file of parseDiff(prDiff)) {
-    if (file.to == null) {
-      continue
-    }
-    debug(`PR file diff: ${file.to} (${file.chunks.length} chunks)`)
-    linesSet[file.to] = {}
-    for (const chunk of file.chunks) {
-      for (const change of chunk.changes) {
-        if (change.type === 'add') {
-          linesSet[file.to][change?.ln] = true
-        }
-      }
-    }
-  }
-  debug(`linesSet: ${JSON.stringify(linesSet)}`)
+  const addedLines = parseAddedLines(prDiff)
 
   const comments = []
   for (const issue of issues) {
     debug(`Processing issue on ${issue.path}:${issue.line}`)
-    if (issue.path == null || issue.line == null) {
-      continue
-    }
-
-    const normalized = normalizePath(issue.path, analysisPath)
-    debug(`Normalized path: ${normalized}`)
-
-    if (
-      (() => {
-        for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
-          if (!linesSet?.[normalized]?.[line]) {
-            return true
-          }
-        }
-        return false
-      })()
-    ) {
-      debug(`Skipping issue on ${normalized}:${issue.line} because it's not in the PR diff`)
+    if (!isNewIssue(issue, addedLines, analysisPath)) {
+      debug(`Skipping issue on ${issue.path}:${issue.line} because it's not in the PR diff`)
       continue
     }
     if (comments.length >= 50) {
@@ -232,7 +201,7 @@ export async function addComments(
 
     const endLine = issue.eline ?? issue.line
     const args = {
-      path: normalized,
+      path: normalizePath(issue.path, analysisPath),
       side: 'RIGHT',
       start_side: 'RIGHT',
       line: endLine,
@@ -249,6 +218,57 @@ export async function addComments(
   debug('Sending comments')
   await octokit.rest.pulls.createReview({ owner, repo, pull_number: prNumber, event: 'COMMENT', comments })
   debug('Sent comments')
+}
+
+export type AddedLines = Record<string, Record<number, boolean>>
+
+export async function getPrDiff(githubToken: string, owner: string, repo: string, prNumber: number): Promise<string> {
+  const octokit = getOctokit(githubToken)
+  return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data as unknown as string
+}
+
+export function parseAddedLines(diff: string): AddedLines {
+  const addedLines: AddedLines = {}
+  for (const file of parseDiff(diff)) {
+    if (file.to == null) {
+      continue
+    }
+    debug(`PR file diff: ${file.to} (${file.chunks.length} chunks)`)
+    addedLines[file.to] = {}
+    for (const chunk of file.chunks) {
+      for (const change of chunk.changes) {
+        if (change.type === 'add') {
+          addedLines[file.to][change?.ln] = true
+        }
+      }
+    }
+  }
+  debug(`addedLines: ${JSON.stringify(addedLines)}`)
+  return addedLines
+}
+
+export function isNewIssue(issue: Issue, addedLines: AddedLines, analysisPath: string): issue is Issue & Required<Pick<Issue, 'path' | 'line'>> {
+  if (issue.path == null || issue.line == null) {
+    return false
+  }
+  const normalized = normalizePath(issue.path, analysisPath)
+  for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
+    if (!addedLines?.[normalized]?.[line]) {
+      return false
+    }
+  }
+  return true
+}
+
+export function failOnIssues(issues: Iterable<Issue>, toolName: string, analysisPath: string, prDiff?: string): void {
+  let failing = [...issues]
+  if (prDiff != null) {
+    const addedLines = parseAddedLines(prDiff)
+    failing = failing.filter((issue) => isNewIssue(issue, addedLines, analysisPath))
+  }
+  if (failing.length > 0) {
+    throw new Error(`${toolName} found ${failing.length} issues`)
+  }
 }
 
 export async function createSummary(issues: Iterable<Issue>, identifier: string, analysisPath: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs'
 import type { Result } from 'sarif'
 import { context } from '@actions/github'
 import { getInput, getBooleanInput, debug, info, setFailed } from '@actions/core'
-import { generateSarif, getKnownParser, getRegexParser, addComments, createSummary, type Parser } from '../src/bugalint'
+import { generateSarif, getKnownParser, getRegexParser, getPrDiff, addComments, createSummary, failOnIssues, type Parser } from '../src/bugalint'
 
 export async function run(): Promise<void> {
   try {
@@ -10,6 +10,8 @@ export async function run(): Promise<void> {
     const sarif: string = getInput('sarif')
     const comment: boolean = getBooleanInput('comment')
     const summary: boolean = getBooleanInput('summary')
+    const fail: boolean = getBooleanInput('fail')
+    const failOnlyNew: boolean = getBooleanInput('failOnlyNew')
     const toolName: string = getInput('toolName')
     const inputFormat: string = getInput('inputFormat')
     const inputRegex: string = getInput('inputRegex')
@@ -28,15 +30,22 @@ export async function run(): Promise<void> {
     if (sarif !== '') {
       writeFileSync(sarif, JSON.stringify(output))
     }
-    if (comment) {
+    let prDiff: string | undefined
+    if (comment || (fail && failOnlyNew)) {
       const prNumber = context.payload.pull_request?.number
       if (prNumber == null) {
         throw new Error('No pull request number found.')
       }
-      await addComments(parser(input), githubToken, toolName, context.repo.owner, context.repo.repo, prNumber, analysisPath)
+      prDiff = await getPrDiff(githubToken, context.repo.owner, context.repo.repo, prNumber)
+      if (comment) {
+        await addComments(parser(input), prDiff, githubToken, toolName, context.repo.owner, context.repo.repo, prNumber, analysisPath)
+      }
     }
     if (summary) {
       await createSummary(parser(input), toolName, analysisPath)
+    }
+    if (fail) {
+      failOnIssues(parser(input), toolName, analysisPath, failOnlyNew ? prDiff : undefined)
     }
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
## What

Adds a feature to fail the step when the linter finds issues, controlled by two boolean inputs:

- `fail` (default `true`): fail the step if any issues are found.
- `failOnlyNew` (default `false`): only count issues located on lines added in the pull request (uses the same PR diff logic as comment mode). Requires a pull request context.

The failure happens after the SARIF/comments/summary outputs are produced, so they are still generated. Error message: `<toolName> found N issues`.

## Implementation

- Extracted the PR-diff logic already used by comment mode into reusable helpers (`getPrDiff`, `parseAddedLines`, `isNewIssue`) in `bugalint.ts`; `addComments` now uses them (behavior unchanged).
- The PR diff is fetched **once** in `index.ts` (when commenting or when `fail` + `failOnlyNew` require it) and passed to both `addComments` and `failOnIssues`.
- New `failOnIssues` in `bugalint.ts` is a small synchronous function: it throws `<toolName> found N issues`, filtering to added lines when a diff is given; the existing catch-all in `index.ts` turns the error into `setFailed`.

## Breaking change

The action now fails by default when issues are found. Set `fail: 'false'` to keep the old behavior.

## Testing

- Unit tests for `parseAddedLines` and `isNewIssue` (added-line parsing, multi-line issues, path re-relativization via `analysisPath`, missing path/line).
- Unit tests for `failOnIssues`: throws with correct count, no-op on zero issues, diff-based filtering (both hit and miss).
- The CI `gha` matrix drives `fail`/`failOnlyNew` per entry and asserts the step outcome (`continue-on-error` + expected outcome check):
  - all existing fixtures (which have issues) run with the default `fail: true` and must **fail**;
  - a new `noissues` fixture (empty input) must **succeed** with both `fail: true` and `fail: false`;
  - `pylint` (has issues) must **succeed** with `fail: false`;
  - `pylint` with `failOnlyNew: true` must **succeed** — the fixture issues point at `test.py`, which is never part of the PR's own diff, so this exercises the real diff-fetch + filtering path end-to-end.
  - The SARIF json-diff check still runs for every entry (the file is written before the step fails).