### PR TITLE
feat: render SARIF fixes and formatter diffs as GitHub suggestions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+# The carriage returns of this fixture are the content under test, so they must survive a checkout on any platform
+__tests__/diffcrlf.input.txt -text

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -80,6 +80,7 @@ jobs:
           - {linter: 'yamllint', format: 'yamllint', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'ghalint', format: 'ghalint', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'sarif', format: 'sarif', regex: '', levelMap: '', analysisPath: '.'}
+          - {linter: 'sariffix', format: 'sarif', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'flake8subpath', format: 'flake8', regex: '', levelMap: '', analysisPath: 'A\B'}
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', outcome: 'success'}
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'noissues-nofail'}

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -81,7 +81,9 @@ jobs:
           - {linter: 'ghalint', format: 'ghalint', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'sarif', format: 'sarif', regex: '', levelMap: '', analysisPath: '.'}
           - {linter: 'sariffix', format: 'sarif', regex: '', levelMap: '', analysisPath: '.'}
-          - {linter: 'flake8subpath', format: 'flake8', regex: '', levelMap: '', analysisPath: 'A\B'}
+          - {linter: 'diff', format: 'diff', regex: '', levelMap: '', analysisPath: '.', message: 'Not formatted correctly'}
+          - {linter: 'diffcrlf', format: 'diff', regex: '', levelMap: '', analysisPath: '.'}
+          - {linter: 'flake8subpath', format: 'flake8', regex: '', levelMap: '', analysisPath: 'A\B', message: 'Fix it'}
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', outcome: 'success'}
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'noissues-nofail'}
           - {linter: 'pylint', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'pylint-nofail'}
@@ -111,6 +113,7 @@ jobs:
           analysisPath: ${{ matrix.run.analysisPath }}
           fail: ${{ matrix.run.fail || 'true' }}
           failOnlyNew: ${{ matrix.run.failOnlyNew || 'false' }}
+          message: ${{ matrix.run.message || '' }}
       - name: Test Outcome
         run: |
           if [ "${{ steps.run.outcome }}" != "${{ matrix.run.outcome || 'failure' }}" ];

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -87,7 +87,7 @@ jobs:
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', outcome: 'success'}
           - {linter: 'noissues', format: 'flake8', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'noissues-nofail'}
           - {linter: 'pylint', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', fail: 'false', outcome: 'success', name: 'pylint-nofail'}
-          - {linter: 'pylint', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', failOnlyNew: 'true', outcome: 'success', name: 'pylint-onlynew'}
+          - {linter: 'pylintonlynew', format: 'pylint', regex: '', levelMap: '', analysisPath: '.', onlyNew: 'true', outcome: 'success'}
           - linter: 'custom'
             format: ''
             # yamllint disable-line rule:line-length
@@ -112,7 +112,7 @@ jobs:
           levelMap: ${{ matrix.run.levelMap }}
           analysisPath: ${{ matrix.run.analysisPath }}
           fail: ${{ matrix.run.fail || 'true' }}
-          failOnlyNew: ${{ matrix.run.failOnlyNew || 'false' }}
+          onlyNew: ${{ matrix.run.onlyNew || 'false' }}
           message: ${{ matrix.run.message || '' }}
       - name: Test Outcome
         run: |

--- a/.github/workflows/check-general.yml
+++ b/.github/workflows/check-general.yml
@@ -36,5 +36,6 @@ jobs:
           checks: |-
             GitHub Action.*
             Check.*
+            Jest.*
             .*[lL]int.*
           self: Required Checks

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ steps:
   root. This is required only when the linter's output contains paths that are relative but not to the repository's root, for which this action will
   re-relativize them.
 
+- `message`: An additional message to append to the message of every issue found. Input formats that carry no message of their own, currently only `diff`, end
+  up with this as their whole message. Empty by default, which leaves the issues of such a format with no message at all.
+
 - `githubToken`: Relevant only for "comment" mode. The GitHub token to use to post the comment. If not specified, the action will use the action's token.
 
 #### Natively Supported Linter Output Formats
@@ -88,7 +91,41 @@ This action supports a bunch of linter output formats, for which no `inputRegex`
 - `ghalint`: The format of [ghallint](https://github.com/suzuki-shunsuke/ghalint/cmd/ghalint/) linter's parsable output.
 
 - `SARIF`: A [standard format for static analysis](https://sarifweb.azurewebsites.net/). This is useful if you already have a SARIF file and want to create a summary
-  for it, or create comments on the PR. This is also the only input format that can carry [suggested changes](#suggested-changes).
+  for it, or create comments on the PR. It can carry [suggested changes](#suggested-changes).
+
+- `diff`: The output of `git diff`, which turns [any formatter that rewrites files in place](#formatter-diffs) into a linter reporting suggested changes.
+
+#### Formatter Diffs
+
+The `diff` input format turns the output of `git diff` into issues, which makes any formatter that can rewrite files in place a linter reporting
+[suggested changes](#suggested-changes):
+
+```yaml
+- run: clang-format -i $(git ls-files '*.cpp')
+- run: git diff > clang-format.diff
+- uses: bugale/bugalint@v1
+  with:
+    inputFile: 'clang-format.diff'
+    toolName: 'clang-format'
+    inputFormat: 'diff'
+    message: 'Not formatted according to .clang-format'
+    comment: true
+```
+
+Every contiguous run of changed lines becomes one issue, rather than every hunk, so the context lines `git diff` prints around each change do not widen the
+reported range. Issues are anchored on the lines of the old side of the diff, which are the lines of the committed file that the pull request shows and that
+comments can be attached to, while the new side becomes the fix. A run that only adds lines has no line of its own to anchor to, so it is extended to a
+neighbouring line, preferring the preceding one, whose content is repeated in the fix. The marker `git diff` prints for a file that does not end with a newline
+is ignored, so the last line of such a file is reported like any other. A change of that terminator alone leaves the old and the new lines identical, so the
+issue is reported without a fix rather than with a suggestion replacing a line with itself. A run replacing lines with nothing deletes them, while one replacing
+them with an empty line blanks them, which is what a formatter stripping the whitespace of a blank line produces. GitHub cannot render a suggestion whose whole
+content is one empty line, so such a run is extended to a neighbouring line as well, and is reported without a fix when there is no line to extend to.
+
+Note that a formatter that fails without writing anything produces an empty diff, which is indistinguishable from a formatter that found nothing to fix. The
+step running the formatter should therefore fail the job by itself.
+
+Unlike the other input formats, a diff is read byte for byte, since a carriage return in it may be content rather than a line terminator. A repository storing
+its files with CRLF therefore gets suggestions with CRLF in them, instead of suggestions that silently rewrite the line endings of every line they touch.
 
 #### Input Regex Named Groups
 
@@ -120,8 +157,8 @@ The supported named groups are:
 
 When an issue carries a fix, the comment posted on the pull request contains it as a
 [suggested change](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request),
-which a reviewer can apply in one click. Fixes are read from the first `replacements` entry of the first `artifactChanges` entry of the result's first `fixes`
-entry, so they are only available when `inputFormat` is `sarif`:
+which a reviewer can apply in one click. Fixes are produced by the [`diff` input format](#formatter-diffs), and are read from the first `replacements` entry of
+the first `artifactChanges` entry of the result's first `fixes` entry when `inputFormat` is `sarif`:
 
 ```json
 {
@@ -154,9 +191,15 @@ Any other `deletedRegion`, such as one replacing a part of a line or lines other
 ignored, and the issue is commented on without one.
 
 The text itself is never trimmed beyond the single line terminator described above, so an additional trailing newline is rendered as a trailing empty line.
-An empty `insertedContent.text` renders as an empty suggestion, which deletes the lines. A replacement consisting of a single empty line is written exactly the
-same way in either form, so it is indistinguishable from a deletion and cannot be expressed. A producer that needs one should widen the replacement to include
-a neighbouring line.
+An empty `insertedContent.text` renders as an empty suggestion, which deletes the lines, in both forms. Replacing the lines with a single empty line is
+therefore expressible only in the second form, as a text of exactly one newline — in the first form that same replacement is written as an empty text, which
+cannot be told apart from a deletion. A producer restricted to the first form should widen the replacement to include a neighbouring line.
+
+GitHub itself cannot render such a replacement either: a suggestion whose whole content is one empty line is drawn, and applied, exactly like an empty one, so
+it deletes the lines instead of blanking them. A fix replacing the lines with a single empty line is therefore read and written faithfully, but is never
+commented as a suggestion. To have one commented, widen the replacement to cover a neighbouring line as well, so that its text is not a lone newline.
+
+The fixes Bugalint writes out always use the second form, so a fix survives being read back from a SARIF file that Bugalint itself generated.
 
 ### Example With Custom Regex
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ such a region are accepted:
 Any other `deletedRegion`, such as one replacing a part of a line or lines other than the reported ones, cannot be rendered as a suggestion. Such a fix is
 ignored, and the issue is commented on without one.
 
+An `endLine` before its own `startLine` describes no range at all. In every input format such an end line is ignored and the issue is anchored on its start
+line alone, which is also what its fix is matched against. The generated SARIF therefore never reports a region ending before it starts.
+
 The text itself is never trimmed beyond the single line terminator described above, so an additional trailing newline is rendered as a trailing empty line.
 An empty `insertedContent.text` renders as an empty suggestion, which deletes the lines, in both forms. Replacing the lines with a single empty line is
 therefore expressible only in the second form, as a text of exactly one newline — in the first form that same replacement is written as an empty text, which

--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ steps:
   repository. If set to an empty string, the action will not write a SARIF file. The SARIF is always generated and printed to the workflow log.
 
 - `comment`: Set to true to comment on the PR with the issues. If set to false or ommitted, the action will not comment on the PR. Issues that carry a fix are
-  commented as [suggested changes](#suggested-changes).
+  commented as [suggested changes](#suggested-changes). An issue is commented on only if every line it spans is part of the pull request's diff, as GitHub
+  rejects comments anchored outside it.
 
 - `summary`: True by default - generates a markdown summary for the job. If set to false, the action will not generate a markdown summary.
 
 - `fail`: True by default - fails the step if the linter found any issues. If set to false, the action will not fail the step.
 
 - `failOnlyNew`: Set to true to fail only on issues found on lines added in the pull request (requires running on a pull request). If set to false or
-  omitted, the action will fail on any issue. Ignored if `fail` is set to false.
+  omitted, the action will fail on any issue. Ignored if `fail` is set to false. An issue spanning several lines is considered new if any one of them was
+  added, since fixing such an issue usually requires changing the lines around it as well.
 
 - `toolName`: _(required)_ The `tool name` that will be written in the SARIF output. This is used by both code scanning and auto-pr-commenting to resolve fixed
   issues.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ steps:
 - `sarif`: The path to the output SARIF file this action should generate. If not specified, the action will generate a `sarif.json` file in the root of the
   repository. If set to an empty string, the action will not write a SARIF file. The SARIF is always generated and printed to the workflow log.
 
-- `comment`: Set to true to comment on the PR with the issues. If set to false or ommitted, the action will not comment on the PR.
+- `comment`: Set to true to comment on the PR with the issues. If set to false or ommitted, the action will not comment on the PR. Issues that carry a fix are
+  commented as [suggested changes](#suggested-changes).
 
 - `summary`: True by default - generates a markdown summary for the job. If set to false, the action will not generate a markdown summary.
 
@@ -85,7 +86,7 @@ This action supports a bunch of linter output formats, for which no `inputRegex`
 - `ghalint`: The format of [ghallint](https://github.com/suzuki-shunsuke/ghalint/cmd/ghalint/) linter's parsable output.
 
 - `SARIF`: A [standard format for static analysis](https://sarifweb.azurewebsites.net/). This is useful if you already have a SARIF file and want to create a summary
-  for it, or create comments on the PR.
+  for it, or create comments on the PR. This is also the only input format that can carry [suggested changes](#suggested-changes).
 
 #### Input Regex Named Groups
 
@@ -112,6 +113,48 @@ The supported named groups are:
 - `eline`: The end line on which the issue was reported.
 
 - `ecol`: The end column on which the issue was reported.
+
+### Suggested Changes
+
+When an issue carries a fix, the comment posted on the pull request contains it as a
+[suggested change](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request),
+which a reviewer can apply in one click. Fixes are read from the first `replacements` entry of the first `artifactChanges` entry of the result's first `fixes`
+entry, so they are only available when `inputFormat` is `sarif`:
+
+```json
+{
+  "message": { "text": "Not formatted correctly" },
+  "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 3, "endLine": 4 } } }],
+  "fixes": [
+    {
+      "artifactChanges": [
+        {
+          "artifactLocation": { "uri": "test.py" },
+          "replacements": [{ "deletedRegion": { "startLine": 3, "endLine": 4 }, "insertedContent": { "text": "def f():\n    return 1" } }]
+        }
+      ]
+    }
+  ]
+}
+```
+
+GitHub replaces whole lines, so a fix is rendered only when its `deletedRegion` covers exactly the lines of the result's own region, which is what the comment
+is anchored to. Following the SARIF specification, in which an absent `endColumn` means the end of the text of `endLine`, both of the usual ways of writing
+such a region are accepted:
+
+- `{ "startLine": 3, "endLine": 4 }` covers the text of lines 3 to 4 without the line terminator ending line 4, so `insertedContent.text` is the new text of
+  those lines and must not end with a newline.
+
+- `{ "startLine": 3, "startColumn": 1, "endLine": 5, "endColumn": 1 }` covers the same lines including the line terminator ending line 4, so
+  `insertedContent.text` must end with a newline. Exactly one is removed when rendering the suggestion.
+
+Any other `deletedRegion`, such as one replacing a part of a line or lines other than the reported ones, cannot be rendered as a suggestion. Such a fix is
+ignored, and the issue is commented on without one.
+
+The text itself is never trimmed beyond the single line terminator described above, so an additional trailing newline is rendered as a trailing empty line.
+An empty `insertedContent.text` renders as an empty suggestion, which deletes the lines. A replacement consisting of a single empty line is written exactly the
+same way in either form, so it is indistinguishable from a deletion and cannot be expressed. A producer that needs one should widen the replacement to include
+a neighbouring line.
 
 ### Example With Custom Regex
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ Every contiguous run of changed lines becomes one issue, rather than every hunk,
 reported range. Issues are anchored on the lines of the old side of the diff, which are the lines of the committed file that the pull request shows and that
 comments can be attached to, while the new side becomes the fix. A run that only adds lines has no line of its own to anchor to, so it is extended to a
 neighbouring line, preferring the preceding one, whose content is repeated in the fix. The marker `git diff` prints for a file that does not end with a newline
-is ignored, so the last line of such a file is reported like any other. A change of that terminator alone leaves the old and the new lines identical, so the
-issue is reported without a fix rather than with a suggestion replacing a line with itself. A run replacing lines with nothing deletes them, while one replacing
-them with an empty line blanks them, which is what a formatter stripping the whitespace of a blank line produces. GitHub cannot render a suggestion whose whole
-content is one empty line, so such a run is extended to a neighbouring line as well, and is reported without a fix when there is no line to extend to.
+is kept out of the fix, so the last line of such a file is reported like any other. When the formatter adds that terminator, the fix ends with an empty line,
+which is how a suggestion asks GitHub for a newline at the end of a file rather than for a blank line; a change of the terminator alone is therefore reported
+with a suggestion whose text repeats the line and adds that empty line. Removing the terminator is reported without a fix, since no suggestion can express it. A
+run replacing lines with nothing deletes them, while one replacing them with an empty line blanks them, which is what a formatter stripping the whitespace of a
+blank line produces. GitHub cannot render a suggestion whose whole content is one empty line, so such a run is extended to a neighbouring line as well, and is
+reported without a fix when there is no line to extend to.
 
 Note that a formatter that fails without writing anything produces an empty diff, which is indistinguishable from a formatter that found nothing to fix. The
 step running the formatter should therefore fail the job by itself.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ steps:
 
 - `fail`: True by default - fails the step if the linter found any issues. If set to false, the action will not fail the step.
 
-- `failOnlyNew`: Set to true to fail only on issues found on lines added in the pull request (requires running on a pull request). If set to false or
-  omitted, the action will fail on any issue. Ignored if `fail` is set to false. An issue spanning several lines is considered new if any one of them was
-  added, since fixing such an issue usually requires changing the lines around it as well.
+- `onlyNew`: Set to true to ignore every issue that is not on a line added in the pull request (requires running on a pull request). The issues are filtered
+  before anything else happens, so the SARIF file, the workflow log, the summary, the comments and the step's success or failure all reflect only the new
+  issues. If set to false or omitted, the action considers every issue. An issue spanning several lines is considered new if any one of them was added, since
+  fixing such an issue usually requires changing the lines around it as well.
+
+  Note that this also removes the old issues from the SARIF, so uploading it to code scanning resolves their alerts. Leave it unset when the SARIF is uploaded
+  and the alerts of the whole repository should be kept.
 
 - `toolName`: _(required)_ The `tool name` that will be written in the SARIF output. This is used by both code scanning and auto-pr-commenting to resolve fixed
   issues.

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -1,5 +1,6 @@
 import '@microsoft/jest-sarif'
 import { readFileSync } from 'fs'
+import type { Region } from 'sarif'
 import { generateSarif, getKnownParser, getRegexParser, parseAddedLines, isNewIssue, failOnIssues, _testExports, type Parser } from '../src/bugalint'
 
 describe('fullConversion', () => {
@@ -11,6 +12,7 @@ describe('fullConversion', () => {
     ['yamllint', getKnownParser('yamllint'), '.'],
     ['ghalint', getKnownParser('ghalint'), '.'],
     ['sarif', getKnownParser('sarif'), '.'],
+    ['sariffix', getKnownParser('sarif'), '.'],
     ['flake8subpath', getKnownParser('flake8'), 'A\\B'],
     ['noissues', getKnownParser('flake8'), '.'],
     [
@@ -88,6 +90,84 @@ index 1111111..2222222 100644
         failOnIssues([{ path: 'A/B/test.py', line: 1 }], 'test', '.', diff)
       }).not.toThrow()
     })
+  })
+})
+
+describe('commentBody', () => {
+  const tag = '<!-- bugale/bugalint test -->'
+  const header = `${tag}\n**Message**\n[warning:test]`
+  const issue = { level: 'warning' as const, msg: 'Message' }
+  const body = (fix?: string): string => _testExports.buildCommentBody(tag, 'test', fix === undefined ? issue : { ...issue, fix })
+
+  it('omits the suggestion when the issue has no fix', () => {
+    expect(body()).toBe(header)
+  })
+
+  it('appends the suggestion after the identifier line', () => {
+    expect(body('x = 1')).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\`\`\``)
+  })
+
+  it('keeps a multi line fix verbatim', () => {
+    expect(body('def f():\n    return 1')).toBe(`${header}\n\`\`\`suggestion\ndef f():\n    return 1\n\`\`\``)
+  })
+
+  it('renders an empty fix as an empty suggestion, which deletes the lines', () => {
+    expect(body('')).toBe(`${header}\n\`\`\`suggestion\n\`\`\``)
+  })
+
+  it('preserves a trailing newline, which keeps a trailing empty line', () => {
+    expect(body('x = 1\n')).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\n\`\`\``)
+  })
+
+  it('uses a fence longer than the longest backtick run in the fix', () => {
+    expect(body('doc = "```"')).toBe(`${header}\n\`\`\`\`suggestion\ndoc = "\`\`\`"\n\`\`\`\``)
+  })
+})
+
+describe('sarifFix', () => {
+  const fixOf = (region: Region, deletedRegion: Region, text: string): string | undefined => {
+    const log = {
+      version: '2.1.0',
+      runs: [
+        {
+          tool: { driver: { name: 'test' } },
+          results: [
+            {
+              message: { text: 'Message' },
+              locations: [{ physicalLocation: { artifactLocation: { uri: 'test.py' }, region } }],
+              fixes: [{ artifactChanges: [{ artifactLocation: { uri: 'test.py' }, replacements: [{ deletedRegion, insertedContent: { text } }] }] }]
+            }
+          ]
+        }
+      ]
+    }
+    return [...getKnownParser('sarif')(JSON.stringify(log))][0].fix
+  }
+
+  it('takes the text of a region ending at the end of the last reported line', () => {
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb')).toBe('a\nb')
+    expect(fixOf({ startLine: 3 }, { startLine: 3 }, 'a')).toBe('a')
+  })
+
+  it('drops the line terminator of a region ending at the beginning of the following line', () => {
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n')).toBe('a\nb')
+    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, 'a\n')).toBe('a')
+  })
+
+  it('keeps a trailing empty line of both forms', () => {
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb\n')).toBe('a\nb\n')
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n\n')).toBe('a\nb\n')
+  })
+
+  it('ignores a fix replacing a part of a line', () => {
+    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 5, endLine: 3, endColumn: 7 }, '===')).toBeUndefined()
+    expect(fixOf({ startLine: 3 }, { startLine: 3, endLine: 3, endColumn: 10 }, 'a')).toBeUndefined()
+  })
+
+  it('ignores a fix replacing lines other than the reported ones', () => {
+    expect(fixOf({ startLine: 3 }, { startLine: 3, endLine: 4 }, 'a')).toBeUndefined()
+    expect(fixOf({ startLine: 3 }, { startLine: 4 }, 'a')).toBeUndefined()
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, 'a\n')).toBeUndefined()
   })
 })
 

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -372,14 +372,34 @@ describe('diffFormat', () => {
     })
   })
 
-  it('ignores the marker of a file not ending with a newline', () => {
-    expect(firstIssue([...header, '-int  a=0;', '\\ No newline at end of file', '+int a = 0;'])).toMatchObject({ line: 1, eline: 1, fix: ['int a = 0;'] })
+  it('keeps the marker of a file not ending with a newline out of the fix', () => {
+    expect(firstIssue([...header, '-int  a=0;', '\\ No newline at end of file', '+int a = 0;'])).toMatchObject({
+      line: 1,
+      eline: 1,
+      fix: ['int a = 0;', '']
+    })
   })
 
-  it('reports a change of the line terminator alone without a fix replacing a line with itself', () => {
-    const issue = firstIssue([...header, '-int a = 0;', '\\ No newline at end of file', '+int a = 0;'])
+  it('suggests a trailing empty line for a terminator added at the end of a file', () => {
+    expect(firstIssue([...header, '-int a = 0;', '\\ No newline at end of file', '+int a = 0;'])).toMatchObject({
+      line: 1,
+      eline: 1,
+      fix: ['int a = 0;', '']
+    })
+  })
+
+  it('reports a terminator removed at the end of a file without a fix', () => {
+    const issue = firstIssue([...header, '-int a = 0;', '+int a = 0;', '\\ No newline at end of file'])
     expect(issue).toMatchObject({ line: 1, eline: 1 })
     expect(issue).not.toHaveProperty('fix')
+  })
+
+  it('adds no trailing empty line when neither side of the change ends with a newline', () => {
+    expect(firstIssue([...header, '-int  a=0;', '\\ No newline at end of file', '+int a = 0;', '\\ No newline at end of file'])).toMatchObject({
+      line: 1,
+      eline: 1,
+      fix: ['int a = 0;']
+    })
   })
 
   it('extends a blanked line at the top of a file to the following line', () => {

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -215,6 +215,100 @@ describe('sarifFix', () => {
   })
 })
 
+describe('invertedRange', () => {
+  interface ParsedIssue {
+    line?: number
+    eline?: number
+    fix?: string[]
+  }
+
+  const sarifLog = (region: Region, fix = false, deleted: Region = { startLine: 12 }): string =>
+    JSON.stringify({
+      version: '2.1.0',
+      runs: [
+        {
+          tool: { driver: { name: 'test' } },
+          results: [
+            {
+              message: { text: 'Message' },
+              locations: [{ physicalLocation: { artifactLocation: { uri: 'test.py' }, region } }],
+              fixes: fix
+                ? [
+                    {
+                      artifactChanges: [{ artifactLocation: { uri: 'test.py' }, replacements: [{ deletedRegion: deleted, insertedContent: { text: 'x' } }] }]
+                    }
+                  ]
+                : undefined
+            }
+          ]
+        }
+      ]
+    })
+
+  const sarifOf = (region: Region, fix = false, deleted?: Region): ParsedIssue => [...getKnownParser('sarif', '')(sarifLog(region, fix, deleted))][0]
+  const pylintOf = (line: number, endLine: number): ParsedIssue =>
+    [...getKnownParser('pylint', '')(JSON.stringify([{ type: 'warning', path: 'a.py', line, endLine }]))][0]
+  const regexOf = (input: string): ParsedIssue => [...getRegexParser(/^(?<line>\d+):(?<eline>\d+)$/gm, '')(input)][0]
+
+  it('drops a SARIF end line preceding the start line, keeping the anchor the producer got right', () => {
+    expect(sarifOf({ startLine: 12, endLine: 10 }).eline).toBeUndefined()
+    expect(sarifOf({ startLine: 12, endLine: 10 }).line).toBe(12)
+    expect(sarifOf({ startLine: 12, endLine: 12 }).eline).toBe(12)
+    expect(sarifOf({ startLine: 12, endLine: 14 }).eline).toBe(14)
+  })
+
+  it('drops a pylint end line preceding the start line', () => {
+    expect(pylintOf(12, 10).eline).toBeUndefined()
+    expect(pylintOf(12, 14).eline).toBe(14)
+  })
+
+  it('drops a captured end line preceding the start line', () => {
+    expect(regexOf('12:10').eline).toBeUndefined()
+    expect(regexOf('12:14').eline).toBe(14)
+  })
+
+  it('drops an end line one before the start line, where only the result region would have inverted', () => {
+    expect(sarifOf({ startLine: 12, endLine: 11 }).eline).toBeUndefined()
+    expect(pylintOf(12, 11).eline).toBeUndefined()
+    expect(regexOf('12:11').eline).toBeUndefined()
+  })
+
+  it('matches the fix of an inverted region against the start line alone', () => {
+    expect(sarifOf({ startLine: 12, endLine: 10 }, true).fix).toStrictEqual(['x'])
+    expect(sarifOf({ startLine: 12, endLine: 11 }, true).fix).toStrictEqual(['x'])
+  })
+
+  it('ignores a fix whose own deleted region ends before it starts', () => {
+    expect(sarifOf({ startLine: 12, endLine: 10 }, true, { startLine: 12, endLine: 10 }).fix).toBeUndefined()
+    expect(sarifOf({ startLine: 12, endLine: 11 }, true, { startLine: 12, endLine: 11 }).fix).toBeUndefined()
+  })
+
+  it('regenerates neither region of an inverted result inverted', () => {
+    for (const endLine of [10, 11]) {
+      const output = generateSarif([...getKnownParser('sarif', '')(sarifLog({ startLine: 12, endLine }, true))], 'test', '.')
+      expect(output).toBeValidSarifLog()
+      expect(output.runs[0].results?.[0].locations?.[0].physicalLocation?.region).toStrictEqual({
+        startLine: 12,
+        startColumn: undefined,
+        endLine: undefined,
+        endColumn: undefined
+      })
+      expect(output.runs[0].results?.[0].fixes?.[0].artifactChanges[0].replacements[0].deletedRegion).toStrictEqual({
+        startLine: 12,
+        startColumn: 1,
+        endLine: 13,
+        endColumn: 1
+      })
+    }
+  })
+
+  it('never reaches a comment anchor whose start follows its end', () => {
+    const diffLines = parseDiffLines('diff --git a/t.py b/t.py\n--- a/t.py\n+++ b/t.py\n@@ -1,1 +1,3 @@\n x\n+y\n+z\n')
+    expect(isCommentableIssue({ path: 't.py', line: 2, eline: 3 }, diffLines, '.')).toBe(true)
+    expect(isCommentableIssue({ path: 't.py', line: 3, eline: 2 }, diffLines, '.')).toBe(false)
+  })
+})
+
 describe('diffFormat', () => {
   const diffOf = (lines: string[], terminator = '\n'): string => lines.map((line) => `${line}${terminator}`).join('')
   const header = ['diff --git a/a.c b/a.c', 'index 1111111..2222222 100644', '--- a/a.c', '+++ b/a.c', '@@ -1,1 +1,1 @@']

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -328,6 +328,12 @@ describe('prDiff', () => {
   it('fails loudly on a diff that is neither, rather than matching every issue against nothing', () => {
     expect(() => decode({ message: 'Not Found' })).toThrow('returned as object rather than text')
   })
+
+  it('rejects a non-empty diff that yields no file, which a decoded response cannot rule out', () => {
+    expect(() => parseDiffLines('<html><body>Proxy Error</body></html>')).toThrow('no file could be parsed from it')
+    expect(() => parseDiffLines('')).not.toThrow()
+    expect(() => parseDiffLines('diff --git a/a.c b/a.c\ndeleted file mode 100644\n--- a/a.c\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-int a;\n')).not.toThrow()
+  })
 })
 
 describe('windowsFileUrl', () => {

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -15,20 +15,22 @@ import {
 
 describe('fullConversion', () => {
   it.each([
-    ['mypy', getKnownParser('mypy'), '.'],
-    ['pylint', getKnownParser('pylint'), '.'],
-    ['flake8', getKnownParser('flake8'), '.'],
-    ['mdl', getKnownParser('mdl'), '.'],
-    ['yamllint', getKnownParser('yamllint'), '.'],
-    ['ghalint', getKnownParser('ghalint'), '.'],
-    ['sarif', getKnownParser('sarif'), '.'],
-    ['sariffix', getKnownParser('sarif'), '.'],
-    ['flake8subpath', getKnownParser('flake8'), 'A\\B'],
-    ['noissues', getKnownParser('flake8'), '.'],
+    ['mypy', getKnownParser('mypy', ''), '.'],
+    ['pylint', getKnownParser('pylint', ''), '.'],
+    ['flake8', getKnownParser('flake8', ''), '.'],
+    ['mdl', getKnownParser('mdl', ''), '.'],
+    ['yamllint', getKnownParser('yamllint', ''), '.'],
+    ['ghalint', getKnownParser('ghalint', ''), '.'],
+    ['sarif', getKnownParser('sarif', ''), '.'],
+    ['sariffix', getKnownParser('sarif', ''), '.'],
+    ['diff', getKnownParser('diff', 'Not formatted correctly'), '.'],
+    ['flake8subpath', getKnownParser('flake8', 'Fix it'), 'A\\B'],
+    ['noissues', getKnownParser('flake8', ''), '.'],
     [
       'custom',
       getRegexParser(
         /^(?<path>[^-\n]+)(?:-(?<line>\d+))?(?:-(?<col>\d+))?(?:-(?<eline>\d+))?(?:-(?<ecol>\d+))? (?<level>[^:\s]+):(?<id>[^:\s]+):(?<sym>[^:\s]+) (?<msg>.+)$/gm,
+        '',
         { err: 'error', warn: 'warning', info: 'note' }
       ),
       '.'
@@ -114,35 +116,39 @@ describe('commentBody', () => {
   const tag = '<!-- bugale/bugalint test -->'
   const header = `${tag}\n**Message**\n[warning:test]`
   const issue = { level: 'warning' as const, msg: 'Message' }
-  const body = (fix?: string): string => _testExports.buildCommentBody(tag, 'test', fix === undefined ? issue : { ...issue, fix })
+  const body = (fix?: string[]): string => _testExports.buildCommentBody(tag, 'test', fix === undefined ? issue : { ...issue, fix })
 
   it('omits the suggestion when the issue has no fix', () => {
     expect(body()).toBe(header)
   })
 
   it('appends the suggestion after the identifier line', () => {
-    expect(body('x = 1')).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\`\`\``)
+    expect(body(['x = 1'])).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\`\`\``)
   })
 
   it('keeps a multi line fix verbatim', () => {
-    expect(body('def f():\n    return 1')).toBe(`${header}\n\`\`\`suggestion\ndef f():\n    return 1\n\`\`\``)
+    expect(body(['def f():', '    return 1'])).toBe(`${header}\n\`\`\`suggestion\ndef f():\n    return 1\n\`\`\``)
   })
 
-  it('renders an empty fix as an empty suggestion, which deletes the lines', () => {
-    expect(body('')).toBe(`${header}\n\`\`\`suggestion\n\`\`\``)
+  it('renders a fix with no lines as an empty suggestion, which deletes the lines', () => {
+    expect(body([])).toBe(`${header}\n\`\`\`suggestion\n\`\`\``)
   })
 
-  it('preserves a trailing newline, which keeps a trailing empty line', () => {
-    expect(body('x = 1\n')).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\n\`\`\``)
+  it('renders no suggestion for a single empty line, which GitHub cannot tell apart from a deletion', () => {
+    expect(body([''])).toBe(header)
+  })
+
+  it('preserves a trailing empty line', () => {
+    expect(body(['x = 1', ''])).toBe(`${header}\n\`\`\`suggestion\nx = 1\n\n\`\`\``)
   })
 
   it('uses a fence longer than the longest backtick run in the fix', () => {
-    expect(body('doc = "```"')).toBe(`${header}\n\`\`\`\`suggestion\ndoc = "\`\`\`"\n\`\`\`\``)
+    expect(body(['doc = "```"'])).toBe(`${header}\n\`\`\`\`suggestion\ndoc = "\`\`\`"\n\`\`\`\``)
   })
 })
 
 describe('sarifFix', () => {
-  const fixOf = (region: Region, deletedRegion: Region, text: string): string | undefined => {
+  const fixOf = (region: Region, deletedRegion: Region, text: string): string[] | undefined => {
     const log = {
       version: '2.1.0',
       runs: [
@@ -158,22 +164,38 @@ describe('sarifFix', () => {
         }
       ]
     }
-    return [...getKnownParser('sarif')(JSON.stringify(log))][0].fix
+    return [...getKnownParser('sarif', '')(JSON.stringify(log))][0].fix
   }
 
   it('takes the text of a region ending at the end of the last reported line', () => {
-    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb')).toBe('a\nb')
-    expect(fixOf({ startLine: 3 }, { startLine: 3 }, 'a')).toBe('a')
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb')).toStrictEqual(['a', 'b'])
+    expect(fixOf({ startLine: 3 }, { startLine: 3 }, 'a')).toStrictEqual(['a'])
   })
 
   it('drops the line terminator of a region ending at the beginning of the following line', () => {
-    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n')).toBe('a\nb')
-    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, 'a\n')).toBe('a')
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n')).toStrictEqual(['a', 'b'])
+    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, 'a\n')).toStrictEqual(['a'])
   })
 
   it('keeps a trailing empty line of both forms', () => {
-    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb\n')).toBe('a\nb\n')
-    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n\n')).toBe('a\nb\n')
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, endLine: 4 }, 'a\nb\n')).toStrictEqual(['a', 'b', ''])
+    expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 5, endColumn: 1 }, 'a\nb\n\n')).toStrictEqual(['a', 'b', ''])
+  })
+
+  it('reads an empty text as a deletion in both forms', () => {
+    expect(fixOf({ startLine: 3 }, { startLine: 3 }, '')).toStrictEqual([])
+    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, '')).toStrictEqual([])
+  })
+
+  it('reads a lone terminator as a single empty line, which only the second form can express', () => {
+    expect(fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, '\n')).toStrictEqual([''])
+  })
+
+  it('reaches the comment builder with a single empty line, which it renders without a suggestion', () => {
+    const fix = fixOf({ startLine: 3 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, '\n')
+    expect(_testExports.buildCommentBody('<!-- bugale/bugalint test -->', 'test', { level: 'warning', msg: 'Message', fix })).toBe(
+      '<!-- bugale/bugalint test -->\n**Message**\n[warning:test]'
+    )
   })
 
   it('ignores a fix replacing a part of a line', () => {
@@ -185,6 +207,103 @@ describe('sarifFix', () => {
     expect(fixOf({ startLine: 3 }, { startLine: 3, endLine: 4 }, 'a')).toBeUndefined()
     expect(fixOf({ startLine: 3 }, { startLine: 4 }, 'a')).toBeUndefined()
     expect(fixOf({ startLine: 3, endLine: 4 }, { startLine: 3, startColumn: 1, endLine: 4, endColumn: 1 }, 'a\n')).toBeUndefined()
+  })
+})
+
+describe('diffFormat', () => {
+  const diffOf = (lines: string[], terminator = '\n'): string => lines.map((line) => `${line}${terminator}`).join('')
+  const header = ['diff --git a/a.c b/a.c', 'index 1111111..2222222 100644', '--- a/a.c', '+++ b/a.c', '@@ -1,1 +1,1 @@']
+  const firstIssue = (lines: string[], terminator = '\n'): unknown => [...getKnownParser('diff', '')(diffOf(lines, terminator))][0]
+
+  it('carries no message of its own, so the configured one becomes the whole message', () => {
+    const input = diffOf([...header, '-int  a=0;', '+int a = 0;'])
+    expect([...getKnownParser('diff', 'Run clang-format')(input)][0].msg).toBe('Run clang-format')
+    expect([...getKnownParser('diff', '')(input)][0].msg).toBeUndefined()
+  })
+
+  it('appends the configured message to the message a parser produces on its own', () => {
+    expect([...getKnownParser('flake8', 'Fix it')('a.py:1:1: E1 Bad')][0].msg).toBe('Bad Fix it')
+    expect([...getRegexParser(/^(?<msg>.+)$/gm, 'Fix it')('Bad')][0].msg).toBe('Bad Fix it')
+  })
+
+  it('anchors on the lines of the old side of the diff', () => {
+    const lines = [
+      'diff --git a/a.c b/a.c',
+      '--- a/a.c',
+      '+++ b/a.c',
+      '@@ -10,4 +2,3 @@',
+      ' int a = 0;',
+      '-int  b=1;',
+      '-int  c=2;',
+      '+int b = 1, c = 2;',
+      ' return a;'
+    ]
+    expect(firstIssue(lines)).toMatchObject({ path: 'a.c', line: 11, eline: 12, fix: ['int b = 1, c = 2;'] })
+  })
+
+  it('reports a deletion as a fix with no lines', () => {
+    expect(firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -5,3 +5,2 @@', ' int a = 0;', '-', ' return a;'])).toMatchObject({
+      line: 6,
+      eline: 6,
+      fix: []
+    })
+  })
+
+  it('distinguishes blanking a line from deleting it, extending it to the preceding line', () => {
+    expect(firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -5,3 +5,3 @@', ' int a = 0;', '-    ', '+', ' return a;'])).toMatchObject({
+      line: 5,
+      eline: 6,
+      fix: ['int a = 0;', '']
+    })
+  })
+
+  it('extends an insertion to the preceding line', () => {
+    expect(firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -4,2 +4,3 @@', ' int a = 0;', '+int b = 1;', ' return a;'])).toMatchObject({
+      line: 4,
+      eline: 4,
+      fix: ['int a = 0;', 'int b = 1;']
+    })
+  })
+
+  it('extends an insertion at the top of a file to the following line', () => {
+    expect(firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -1,2 +1,3 @@', '+// header', ' int a = 0;', ' return a;'])).toMatchObject({
+      line: 1,
+      eline: 1,
+      fix: ['// header', 'int a = 0;']
+    })
+  })
+
+  it('ignores the marker of a file not ending with a newline', () => {
+    expect(firstIssue([...header, '-int  a=0;', '\\ No newline at end of file', '+int a = 0;'])).toMatchObject({ line: 1, eline: 1, fix: ['int a = 0;'] })
+  })
+
+  it('reports a change of the line terminator alone without a fix replacing a line with itself', () => {
+    const issue = firstIssue([...header, '-int a = 0;', '\\ No newline at end of file', '+int a = 0;'])
+    expect(issue).toMatchObject({ line: 1, eline: 1 })
+    expect(issue).not.toHaveProperty('fix')
+  })
+
+  it('extends a blanked line at the top of a file to the following line', () => {
+    expect(firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -1,2 +1,2 @@', '-    ', '+', ' int a = 0;'])).toMatchObject({
+      line: 1,
+      eline: 2,
+      fix: ['', 'int a = 0;']
+    })
+  })
+
+  it('reports a blanked line with no line to extend to without a fix', () => {
+    const issue = firstIssue(['diff --git a/a.c b/a.c', '--- a/a.c', '+++ b/a.c', '@@ -1,1 +1,1 @@', '-    ', '+'])
+    expect(issue).toMatchObject({ line: 1, eline: 1 })
+    expect(issue).not.toHaveProperty('fix')
+  })
+
+  it('keeps carriage returns that are part of the content', () => {
+    expect(firstIssue([...header, '-int  a=0;\r', '+int a = 0;\r'])).toMatchObject({ fix: ['int a = 0;\r'] })
+  })
+
+  it('strips the carriage returns of a diff whose own lines are terminated by them', () => {
+    expect(firstIssue([...header, '-int  a=0;', '+int a = 0;'], '\r\n')).toMatchObject({ fix: ['int a = 0;'] })
+    expect(firstIssue([...header, '-int  a=0;\r', '+int a = 0;\r'], '\r\n')).toMatchObject({ fix: ['int a = 0;\r'] })
   })
 })
 

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -312,6 +312,24 @@ describe('diffFormat', () => {
   })
 })
 
+describe('prDiff', () => {
+  const decode = (data: unknown): string => _testExports.decodeDiff(data)
+
+  it('passes through a diff returned as text', () => {
+    expect(decode('diff --git a/a.c b/a.c')).toBe('diff --git a/a.c b/a.c')
+  })
+
+  it('decodes a diff returned as a buffer, which happens when the content type is not recognised as text', () => {
+    const bytes = new TextEncoder().encode('diff --git a/a.c b/a.c')
+    expect(decode(bytes.buffer)).toBe('diff --git a/a.c b/a.c')
+    expect(decode(bytes)).toBe('diff --git a/a.c b/a.c')
+  })
+
+  it('fails loudly on a diff that is neither, rather than matching every issue against nothing', () => {
+    expect(() => decode({ message: 'Not Found' })).toThrow('returned as object rather than text')
+  })
+})
+
 describe('windowsFileUrl', () => {
   if (process.platform === 'win32') {
     it('should convert Windows file URLs to relative URLs', () => {

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -9,6 +9,7 @@ import {
   isNewIssue,
   isCommentableIssue,
   failOnIssues,
+  filterNewIssues,
   _testExports,
   type Parser
 } from '../src/bugalint'
@@ -84,30 +85,34 @@ index 1111111..2222222 100644
   describe('failOnIssues', () => {
     it('does nothing when no issues are found', () => {
       expect(() => {
-        failOnIssues([], 'test', '.')
+        failOnIssues([], 'test')
       }).not.toThrow()
     })
 
     it('throws when issues are found', () => {
       expect(() => {
-        failOnIssues([{ path: 'a.py', line: 1 }, { msg: 'x' }], 'test', '.')
+        failOnIssues([{ path: 'a.py', line: 1 }, { msg: 'x' }], 'test')
       }).toThrow('test found 2 issues')
     })
+  })
 
-    it('throws only on new issues when a diff is given', () => {
+  describe('filterNewIssues', () => {
+    it('keeps only the issues overlapping an added line', () => {
       const issues = [
         { path: 'A/B/test.py', line: 1 },
-        { path: 'A/B/test.py', line: 2 }
+        { path: 'A/B/test.py', line: 2 },
+        { path: 'A/B/test.py', line: 1, eline: 2 },
+        { path: 'A/B/other.py', line: 2 }
       ]
-      expect(() => {
-        failOnIssues(issues, 'test', '.', diff)
-      }).toThrow('test found 1 issues')
+      expect(filterNewIssues(issues, diff, '.')).toStrictEqual([issues[1], issues[2]])
     })
 
-    it('does nothing when a diff is given and all issues are old', () => {
-      expect(() => {
-        failOnIssues([{ path: 'A/B/test.py', line: 1 }], 'test', '.', diff)
-      }).not.toThrow()
+    it('keeps nothing when all issues are old', () => {
+      expect(filterNewIssues([{ path: 'A/B/test.py', line: 1 }], diff, '.')).toStrictEqual([])
+    })
+
+    it('relativizes the issue paths to the analysis path', () => {
+      expect(filterNewIssues([{ path: 'test.py', line: 3 }], diff, 'A\\B')).toHaveLength(1)
     })
   })
 })

--- a/__tests__/bugalint.test.ts
+++ b/__tests__/bugalint.test.ts
@@ -1,7 +1,17 @@
 import '@microsoft/jest-sarif'
 import { readFileSync } from 'fs'
 import type { Region } from 'sarif'
-import { generateSarif, getKnownParser, getRegexParser, parseAddedLines, isNewIssue, failOnIssues, _testExports, type Parser } from '../src/bugalint'
+import {
+  generateSarif,
+  getKnownParser,
+  getRegexParser,
+  parseDiffLines,
+  isNewIssue,
+  isCommentableIssue,
+  failOnIssues,
+  _testExports,
+  type Parser
+} from '../src/bugalint'
 
 describe('fullConversion', () => {
   it.each([
@@ -42,24 +52,31 @@ index 1111111..2222222 100644
 +import sys
 +x = 1
 `
-  const addedLines = parseAddedLines(diff)
+  const diffLines = parseDiffLines(diff)
 
-  it('collects added line numbers per file', () => {
-    expect(addedLines).toStrictEqual({ 'A/B/test.py': { 2: true, 3: true } })
+  it('collects the lines of the diff per file, marking the added ones', () => {
+    expect(diffLines).toStrictEqual({ 'A/B/test.py': { 1: false, 2: true, 3: true } })
   })
 
-  it('accepts issues contained in added lines', () => {
-    expect(isNewIssue({ path: 'A/B/test.py', line: 2 }, addedLines, '.')).toBe(true)
-    expect(isNewIssue({ path: 'A/B/test.py', line: 2, eline: 3 }, addedLines, '.')).toBe(true)
-    expect(isNewIssue({ path: 'test.py', line: 3 }, addedLines, 'A\\B')).toBe(true)
+  it('accepts issues overlapping an added line', () => {
+    expect(isNewIssue({ path: 'A/B/test.py', line: 2 }, diffLines, '.')).toBe(true)
+    expect(isNewIssue({ path: 'A/B/test.py', line: 2, eline: 3 }, diffLines, '.')).toBe(true)
+    expect(isNewIssue({ path: 'A/B/test.py', line: 1, eline: 2 }, diffLines, '.')).toBe(true)
+    expect(isNewIssue({ path: 'test.py', line: 3 }, diffLines, 'A\\B')).toBe(true)
   })
 
-  it('rejects issues not fully contained in added lines', () => {
-    expect(isNewIssue({ path: 'A/B/test.py', line: 1 }, addedLines, '.')).toBe(false)
-    expect(isNewIssue({ path: 'A/B/test.py', line: 1, eline: 2 }, addedLines, '.')).toBe(false)
-    expect(isNewIssue({ path: 'A/B/other.py', line: 2 }, addedLines, '.')).toBe(false)
-    expect(isNewIssue({ line: 2 }, addedLines, '.')).toBe(false)
-    expect(isNewIssue({ path: 'A/B/test.py' }, addedLines, '.')).toBe(false)
+  it('rejects issues not overlapping any added line', () => {
+    expect(isNewIssue({ path: 'A/B/test.py', line: 1 }, diffLines, '.')).toBe(false)
+    expect(isNewIssue({ path: 'A/B/other.py', line: 2 }, diffLines, '.')).toBe(false)
+    expect(isNewIssue({ line: 2 }, diffLines, '.')).toBe(false)
+    expect(isNewIssue({ path: 'A/B/test.py' }, diffLines, '.')).toBe(false)
+  })
+
+  it('comments only on issues whose whole range is in the diff', () => {
+    expect(isCommentableIssue({ path: 'A/B/test.py', line: 1, eline: 3 }, diffLines, '.')).toBe(true)
+    expect(isCommentableIssue({ path: 'A/B/test.py', line: 3, eline: 4 }, diffLines, '.')).toBe(false)
+    expect(isCommentableIssue({ path: 'A/B/other.py', line: 1 }, diffLines, '.')).toBe(false)
+    expect(isCommentableIssue({ path: 'A/B/test.py' }, diffLines, '.')).toBe(false)
   })
 
   describe('failOnIssues', () => {

--- a/__tests__/diff.input.txt
+++ b/__tests__/diff.input.txt
@@ -1,0 +1,96 @@
+diff --git a/src/single.c b/src/single.c
+index 1111111..2222222 100644
+--- a/src/single.c
++++ b/src/single.c
+@@ -1,5 +1,5 @@
+ int main() {
+   int a = 0;
+-  int  b=1;
++  int b = 1;
+   return a + b;
+ }
+diff --git a/src/multi.c b/src/multi.c
+index 3333333..4444444 100644
+--- a/src/multi.c
++++ b/src/multi.c
+@@ -8,7 +8,6 @@ void g(void) {
+   int x = 0;
+-  if (x)
+-  {
+-    f(  );
+-  }
++  if (x) {
++    f();
++  }
+   return;
+ }
+diff --git a/src/deletion.c b/src/deletion.c
+index 5555555..6666666 100644
+--- a/src/deletion.c
++++ b/src/deletion.c
+@@ -18,5 +18,3 @@ void h(void) {
+   int y = 0;
+-
+-
+   return;
+ }
+diff --git a/src/insertion.c b/src/insertion.c
+index 7777777..8888888 100644
+--- a/src/insertion.c
++++ b/src/insertion.c
+@@ -30,4 +30,5 @@ void i(void) {
+   int z = 0;
+   int w = 1;
++
+   return;
+ }
+diff --git a/src/top.c b/src/top.c
+index 9999999..aaaaaaa 100644
+--- a/src/top.c
++++ b/src/top.c
+@@ -1,3 +1,4 @@
++// clang-format off
+ #include <stdio.h>
+ #include <stdlib.h>
+ int main(void) {
+diff --git a/src/fence.c b/src/fence.c
+index bbbbbbb..ccccccc 100644
+--- a/src/fence.c
++++ b/src/fence.c
+@@ -40,3 +40,3 @@ void j(void) {
+-  const char* doc = "```";
++  const char *doc = "```";
+   return;
+ }
+diff --git a/src/eof.c b/src/eof.c
+index ddddddd..eeeeeee 100644
+--- a/src/eof.c
++++ b/src/eof.c
+@@ -50,1 +50,1 @@ void k(void) {
+-  int  last=0;
+\ No newline at end of file
++  int last = 0;
+diff --git a/src/blank.c b/src/blank.c
+index fffffff..ggggggg 100644
+--- a/src/blank.c
++++ b/src/blank.c
+@@ -60,3 +60,3 @@ void m(void) {
+   int a = 0;
+-    
++
+   return a;
+diff --git a/src/term.c b/src/term.c
+index hhhhhhh..iiiiiii 100644
+--- a/src/term.c
++++ b/src/term.c
+@@ -70,1 +70,1 @@ void n(void) {
+-  int last = 0;
+\ No newline at end of file
++  int last = 0;
+diff --git a/src/only.c b/src/only.c
+index jjjjjjj..kkkkkkk 100644
+--- a/src/only.c
++++ b/src/only.c
+@@ -1,1 +1,1 @@
+-    
++

--- a/__tests__/diff.output.json
+++ b/__tests__/diff.output.json
@@ -125,7 +125,7 @@
                   "replacements": [
                     {
                       "deletedRegion": { "startLine": 50, "startColumn": 1, "endLine": 51, "endColumn": 1 },
-                      "insertedContent": { "text": "  int last = 0;\n" }
+                      "insertedContent": { "text": "  int last = 0;\n\n" }
                     }
                   ]
                 }
@@ -154,6 +154,21 @@
         {
           "message": { "text": "Not formatted correctly" },
           "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/term.c" }, "region": { "startLine": 70, "endLine": 70 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/term.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 70, "startColumn": 1, "endLine": 71, "endColumn": 1 },
+                      "insertedContent": { "text": "  int last = 0;\n\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
           "level": "warning"
         },
         {

--- a/__tests__/diff.output.json
+++ b/__tests__/diff.output.json
@@ -1,0 +1,167 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "test", "rules": [] } },
+      "results": [
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/single.c" }, "region": { "startLine": 3, "endLine": 3 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/single.c" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 3, "startColumn": 1, "endLine": 4, "endColumn": 1 }, "insertedContent": { "text": "  int b = 1;\n" } }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/multi.c" }, "region": { "startLine": 9, "endLine": 12 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/multi.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 9, "startColumn": 1, "endLine": 13, "endColumn": 1 },
+                      "insertedContent": { "text": "  if (x) {\n    f();\n  }\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/deletion.c" }, "region": { "startLine": 19, "endLine": 20 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/deletion.c" },
+                  "replacements": [{ "deletedRegion": { "startLine": 19, "startColumn": 1, "endLine": 21, "endColumn": 1 }, "insertedContent": { "text": "" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/insertion.c" }, "region": { "startLine": 31, "endLine": 31 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/insertion.c" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 31, "startColumn": 1, "endLine": 32, "endColumn": 1 }, "insertedContent": { "text": "  int w = 1;\n\n" } }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/top.c" }, "region": { "startLine": 1, "endLine": 1 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/top.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 1, "startColumn": 1, "endLine": 2, "endColumn": 1 },
+                      "insertedContent": { "text": "// clang-format off\n#include <stdio.h>\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/fence.c" }, "region": { "startLine": 40, "endLine": 40 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/fence.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 40, "startColumn": 1, "endLine": 41, "endColumn": 1 },
+                      "insertedContent": { "text": "  const char *doc = \"```\";\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/eof.c" }, "region": { "startLine": 50, "endLine": 50 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/eof.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 50, "startColumn": 1, "endLine": 51, "endColumn": 1 },
+                      "insertedContent": { "text": "  int last = 0;\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/blank.c" }, "region": { "startLine": 60, "endLine": 61 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/blank.c" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 60, "startColumn": 1, "endLine": 62, "endColumn": 1 }, "insertedContent": { "text": "  int a = 0;\n\n" } }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/term.c" }, "region": { "startLine": 70, "endLine": 70 } } }],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Not formatted correctly" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/only.c" }, "region": { "startLine": 1, "endLine": 1 } } }],
+          "level": "warning"
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/diffcrlf.input.txt
+++ b/__tests__/diffcrlf.input.txt
@@ -1,0 +1,24 @@
+diff --git a/src/crlf.c b/src/crlf.c
+index 1111111..2222222 100644
+--- a/src/crlf.c
++++ b/src/crlf.c
+@@ -1,5 +1,5 @@
+ int main() {
+   int a = 0;
+-  int  b=1;
++  int b = 1;
+   return a + b;
+ }
+diff --git a/src/crlfmulti.c b/src/crlfmulti.c
+index 3333333..4444444 100644
+--- a/src/crlfmulti.c
++++ b/src/crlfmulti.c
+@@ -1,5 +1,6 @@
+ void g(void) {
+-  int x=0;
+-  int y=1;
++  int x = 0;
++  int y = 1;
+   use(x, y);
++  extra();
+ }

--- a/__tests__/diffcrlf.output.json
+++ b/__tests__/diffcrlf.output.json
@@ -1,0 +1,68 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "test", "rules": [] } },
+      "results": [
+        {
+          "message": { "text": "" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/crlf.c" }, "region": { "startLine": 3, "endLine": 3 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/crlf.c" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 3, "startColumn": 1, "endLine": 4, "endColumn": 1 }, "insertedContent": { "text": "  int b = 1;\r\n" } }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/crlfmulti.c" }, "region": { "startLine": 2, "endLine": 3 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/crlfmulti.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 2, "startColumn": 1, "endLine": 4, "endColumn": 1 },
+                      "insertedContent": { "text": "  int x = 0;\r\n  int y = 1;\r\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/crlfmulti.c" }, "region": { "startLine": 4, "endLine": 4 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "src/crlfmulti.c" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 4, "startColumn": 1, "endLine": 5, "endColumn": 1 },
+                      "insertedContent": { "text": "  use(x, y);\r\n  extra();\r\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/flake8subpath.output.json
+++ b/__tests__/flake8subpath.output.json
@@ -6,21 +6,13 @@
       "tool": { "driver": { "name": "test", "rules": [] } },
       "results": [
         {
-          "locations": [
-            {
-              "physicalLocation": { "artifactLocation": { "uri": "A/B/main.py" }, "region": { "startColumn": 21, "startLine": 85 } }
-            }
-          ],
-          "message": { "text": "multiple spaces after ':'" },
+          "message": { "text": "multiple spaces after ':' Fix it" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "A/B/main.py" }, "region": { "startLine": 85, "startColumn": 21 } } }],
           "ruleId": "E241"
         },
         {
-          "locations": [
-            {
-              "physicalLocation": { "artifactLocation": { "uri": "A/B/c/d/__init__.py" }, "region": { "startColumn": 1, "startLine": 139 } }
-            }
-          ],
-          "message": { "text": "expected 2 blank lines after class or function definition, found 1" },
+          "message": { "text": "expected 2 blank lines after class or function definition, found 1 Fix it" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "A/B/c/d/__init__.py" }, "region": { "startLine": 139, "startColumn": 1 } } }],
           "ruleId": "E305"
         }
       ]

--- a/__tests__/pylintonlynew.input.txt
+++ b/__tests__/pylintonlynew.input.txt
@@ -1,0 +1,67 @@
+[
+  {
+    "type": "convention",
+    "module": "test",
+    "obj": "",
+    "line": 4,
+    "column": 0,
+    "endLine": null,
+    "endColumn": null,
+    "path": "test.py",
+    "symbol": "missing-final-newline",
+    "message": "Final newline missing",
+    "message-id": "C0304"
+  },
+  {
+    "type": "usage",
+    "module": "test",
+    "obj": "a",
+    "line": 3,
+    "column": 0,
+    "endLine": 3,
+    "endColumn": 5,
+    "path": "test.py",
+    "symbol": "missing-function-docstring",
+    "message": "Missing function or method docstring",
+    "message-id": "C0116"
+  },
+  {
+    "type": "refactor",
+    "module": "test",
+    "obj": "a",
+    "line": 3,
+    "column": 0,
+    "endLine": 3,
+    "endColumn": 5,
+    "path": "test.py",
+    "symbol": "missing-function-docstring",
+    "message": "Missing function or method docstring",
+    "message-id": "C0116"
+  },
+  {
+    "type": "warning",
+    "module": "test",
+    "obj": "",
+    "line": 1,
+    "column": 0,
+    "endLine": 1,
+    "endColumn": 10,
+    "path": "test.py",
+    "symbol": "unused-import",
+    "message": "Unused import sys",
+    "message-id": "W0611"
+  },
+  {
+    "type": "error",
+    "module": "test",
+    "obj": "",
+    "line": 1,
+    "column": 0,
+    "endLine": 1,
+    "endColumn": 10,
+    "path": "test.py",
+    "symbol": "unused-import",
+    "message": "Unused import sys",
+    "message-id": "W0611"
+  }
+]

--- a/__tests__/pylintonlynew.output.json
+++ b/__tests__/pylintonlynew.output.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [{ "tool": { "driver": { "name": "test", "rules": [] } }, "results": [] }]
+}

--- a/__tests__/sariffix.input.txt
+++ b/__tests__/sariffix.input.txt
@@ -1,0 +1,153 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "test",
+          "rules": [{ "id": "F001", "name": "formatting" }]
+        }
+      },
+      "results": [
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 3, "endLine": 3 } } }],
+          "level": "warning",
+          "message": { "text": "Single line replacement" },
+          "ruleId": "F001",
+          "ruleIndex": 0,
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 3, "endLine": 3 }, "insertedContent": { "text": "x = 1" } }]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 10, "endLine": 12 } } }],
+          "level": "warning",
+          "message": { "text": "Multi line replacement" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 10, "endLine": 12 }, "insertedContent": { "text": "def f():\n    return 1" } }]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 20, "endLine": 21 } } }],
+          "level": "warning",
+          "message": { "text": "Deletion" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 20, "endLine": 21 }, "insertedContent": { "text": "" } }]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 30, "endLine": 30 } } }],
+          "level": "warning",
+          "message": { "text": "Replacement containing a fence" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 30, "endLine": 30 }, "insertedContent": { "text": "doc = \"```\"" } }]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 40, "endLine": 40 } } }],
+          "level": "error",
+          "message": { "text": "No fix available" }
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 50, "endLine": 51 } } }],
+          "level": "warning",
+          "message": { "text": "Deleted region including the line terminator" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 50, "startColumn": 1, "endLine": 52, "endColumn": 1 },
+                      "insertedContent": { "text": "a = 1\nb = 2\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 60, "endLine": 60 } } }],
+          "level": "warning",
+          "message": { "text": "Replacement of a part of a line" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 60, "startColumn": 5, "endLine": 60, "endColumn": 7 },
+                      "insertedContent": { "text": "===" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 70, "endLine": 70 } } }],
+          "level": "warning",
+          "message": { "text": "Replacement of lines other than the reported ones" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 70, "endLine": 71 }, "insertedContent": { "text": "y = 2" } }]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 80, "endLine": 80 } } }],
+          "level": "warning",
+          "message": { "text": "Replacement ending with an empty line" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 80, "endLine": 80 }, "insertedContent": { "text": "z = 3\n" } }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/sariffix.input.txt
+++ b/__tests__/sariffix.input.txt
@@ -146,6 +146,26 @@
               ]
             }
           ]
+        },
+        {
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 90, "endLine": 90 } } }],
+          "level": "warning",
+          "message": { "text": "Blanking a line rather than deleting it" },
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 90, "startColumn": 1, "endLine": 91, "endColumn": 1 },
+                      "insertedContent": { "text": "\n" }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/__tests__/sariffix.output.json
+++ b/__tests__/sariffix.output.json
@@ -1,0 +1,118 @@
+{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.6",
+  "runs": [
+    {
+      "tool": { "driver": { "name": "test", "rules": [{ "id": "F001", "name": "formatting" }] } },
+      "results": [
+        {
+          "message": { "text": "Single line replacement" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 3, "endLine": 3 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 3, "endLine": 3 }, "insertedContent": { "text": "x = 1" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning",
+          "ruleId": "F001",
+          "ruleIndex": 0
+        },
+        {
+          "message": { "text": "Multi line replacement" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 10, "endLine": 12 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 10, "endLine": 12 }, "insertedContent": { "text": "def f():\n    return 1" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Deletion" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 20, "endLine": 21 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 20, "endLine": 21 }, "insertedContent": { "text": "" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Replacement containing a fence" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 30, "endLine": 30 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 30, "endLine": 30 }, "insertedContent": { "text": "doc = \"```\"" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "No fix available" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 40, "endLine": 40 } } }],
+          "level": "error"
+        },
+        {
+          "message": { "text": "Deleted region including the line terminator" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 50, "endLine": 51 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 50, "endLine": 51 }, "insertedContent": { "text": "a = 1\nb = 2" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Replacement of a part of a line" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 60, "endLine": 60 } } }],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Replacement of lines other than the reported ones" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 70, "endLine": 70 } } }],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Replacement ending with an empty line" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 80, "endLine": 80 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [{ "deletedRegion": { "startLine": 80, "endLine": 80 }, "insertedContent": { "text": "z = 3\n" } }]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        }
+      ]
+    }
+  ]
+}

--- a/__tests__/sariffix.output.json
+++ b/__tests__/sariffix.output.json
@@ -13,7 +13,9 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 3, "endLine": 3 }, "insertedContent": { "text": "x = 1" } }]
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 3, "startColumn": 1, "endLine": 4, "endColumn": 1 }, "insertedContent": { "text": "x = 1\n" } }
+                  ]
                 }
               ]
             }
@@ -30,7 +32,12 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 10, "endLine": 12 }, "insertedContent": { "text": "def f():\n    return 1" } }]
+                  "replacements": [
+                    {
+                      "deletedRegion": { "startLine": 10, "startColumn": 1, "endLine": 13, "endColumn": 1 },
+                      "insertedContent": { "text": "def f():\n    return 1\n" }
+                    }
+                  ]
                 }
               ]
             }
@@ -45,7 +52,7 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 20, "endLine": 21 }, "insertedContent": { "text": "" } }]
+                  "replacements": [{ "deletedRegion": { "startLine": 20, "startColumn": 1, "endLine": 22, "endColumn": 1 }, "insertedContent": { "text": "" } }]
                 }
               ]
             }
@@ -60,7 +67,9 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 30, "endLine": 30 }, "insertedContent": { "text": "doc = \"```\"" } }]
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 30, "startColumn": 1, "endLine": 31, "endColumn": 1 }, "insertedContent": { "text": "doc = \"```\"\n" } }
+                  ]
                 }
               ]
             }
@@ -80,7 +89,9 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 50, "endLine": 51 }, "insertedContent": { "text": "a = 1\nb = 2" } }]
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 50, "startColumn": 1, "endLine": 52, "endColumn": 1 }, "insertedContent": { "text": "a = 1\nb = 2\n" } }
+                  ]
                 }
               ]
             }
@@ -105,7 +116,26 @@
               "artifactChanges": [
                 {
                   "artifactLocation": { "uri": "test.py" },
-                  "replacements": [{ "deletedRegion": { "startLine": 80, "endLine": 80 }, "insertedContent": { "text": "z = 3\n" } }]
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 80, "startColumn": 1, "endLine": 81, "endColumn": 1 }, "insertedContent": { "text": "z = 3\n\n" } }
+                  ]
+                }
+              ]
+            }
+          ],
+          "level": "warning"
+        },
+        {
+          "message": { "text": "Blanking a line rather than deleting it" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "test.py" }, "region": { "startLine": 90, "endLine": 90 } } }],
+          "fixes": [
+            {
+              "artifactChanges": [
+                {
+                  "artifactLocation": { "uri": "test.py" },
+                  "replacements": [
+                    { "deletedRegion": { "startLine": 90, "startColumn": 1, "endLine": 91, "endColumn": 1 }, "insertedContent": { "text": "\n" } }
+                  ]
                 }
               ]
             }

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,8 @@ inputs:
     description: 'Should the action fail the step if issues are found'
     required: false
     default: 'true'
-  failOnlyNew:
-    description: 'Should the action fail only on issues found on lines added in the pull request'
+  onlyNew:
+    description: 'Should the action consider only issues found on lines added in the pull request, ignoring all others everywhere'
     required: false
     default: 'false'
   toolName:

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,10 @@ inputs:
     description: "The path at which the analysis took place relative to the repository's root. Used to relativize any paths to the repository root path."
     required: false
     default: '.'
+  message:
+    description: 'Additional message to append to every issue found. The only message of formats that do not carry one, such as diff'
+    required: false
+    default: ''
   githubToken:
     description: 'Github token of the repository (automatically created by Github)'
     default: ${{ github.token }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -29938,8 +29938,9 @@ exports.getKnownParser = getKnownParser;
 exports.getRegexParser = getRegexParser;
 exports.addComments = addComments;
 exports.getPrDiff = getPrDiff;
-exports.parseAddedLines = parseAddedLines;
+exports.parseDiffLines = parseDiffLines;
 exports.isNewIssue = isNewIssue;
+exports.isCommentableIssue = isCommentableIssue;
 exports.failOnIssues = failOnIssues;
 exports.createSummary = createSummary;
 const github_1 = __nccwpck_require__(3228);
@@ -30125,12 +30126,12 @@ async function addComments(issues, prDiff, githubToken, identifier, owner, repo,
             }
         }
     }
-    const addedLines = parseAddedLines(prDiff);
+    const diffLines = parseDiffLines(prDiff);
     const comments = [];
     for (const issue of issues) {
         (0, core_1.debug)(`Processing issue on ${issue.path}:${issue.line}`);
-        if (!isNewIssue(issue, addedLines, analysisPath)) {
-            (0, core_1.debug)(`Skipping issue on ${issue.path}:${issue.line} because it's not in the PR diff`);
+        if (!isCommentableIssue(issue, diffLines, analysisPath)) {
+            (0, core_1.debug)(`Skipping issue on ${issue.path}:${issue.line} because it is not on lines the pull request diff shows`);
             continue;
         }
         if (comments.length >= 50) {
@@ -30161,42 +30162,50 @@ async function getPrDiff(githubToken, owner, repo, prNumber) {
     const octokit = (0, github_1.getOctokit)(githubToken);
     return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data;
 }
-function parseAddedLines(diff) {
-    const addedLines = {};
+function parseDiffLines(diff) {
+    const diffLines = {};
     for (const file of (0, parse_diff_1.default)(diff)) {
         if (file.to == null) {
             continue;
         }
         (0, core_1.debug)(`PR file diff: ${file.to} (${file.chunks.length} chunks)`);
-        addedLines[file.to] = {};
+        diffLines[file.to] = {};
         for (const chunk of file.chunks) {
             for (const change of chunk.changes) {
                 if (change.type === 'add') {
-                    addedLines[file.to][change?.ln] = true;
+                    diffLines[file.to][change.ln] = true;
+                }
+                else if (change.type === 'normal') {
+                    diffLines[file.to][change.ln2] = false;
                 }
             }
         }
     }
-    (0, core_1.debug)(`addedLines: ${JSON.stringify(addedLines)}`);
-    return addedLines;
+    (0, core_1.debug)(`diffLines: ${JSON.stringify(diffLines)}`);
+    return diffLines;
 }
-function isNewIssue(issue, addedLines, analysisPath) {
+function issueLines(line, eline) {
+    return Array.from({ length: (eline ?? line) - line + 1 }, (_, offset) => line + offset);
+}
+function isNewIssue(issue, diffLines, analysisPath) {
     if (issue.path == null || issue.line == null) {
         return false;
     }
-    const normalized = normalizePath(issue.path, analysisPath);
-    for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
-        if (!addedLines?.[normalized]?.[line]) {
-            return false;
-        }
+    const lines = diffLines[normalizePath(issue.path, analysisPath)];
+    return issueLines(issue.line, issue.eline).some((line) => lines?.[line] ?? false);
+}
+function isCommentableIssue(issue, diffLines, analysisPath) {
+    if (!isNewIssue(issue, diffLines, analysisPath)) {
+        return false;
     }
-    return true;
+    const lines = diffLines[normalizePath(issue.path, analysisPath)];
+    return issueLines(issue.line, issue.eline).every((line) => lines?.[line] != null);
 }
 function failOnIssues(issues, toolName, analysisPath, prDiff) {
     let failing = [...issues];
     if (prDiff != null) {
-        const addedLines = parseAddedLines(prDiff);
-        failing = failing.filter((issue) => isNewIssue(issue, addedLines, analysisPath));
+        const diffLines = parseDiffLines(prDiff);
+        failing = failing.filter((issue) => isNewIssue(issue, diffLines, analysisPath));
     }
     if (failing.length > 0) {
         throw new Error(`${toolName} found ${failing.length} issues`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -29948,18 +29948,22 @@ const github_1 = __nccwpck_require__(3228);
 const core_1 = __nccwpck_require__(7484);
 const path_1 = __importDefault(__nccwpck_require__(6928));
 const parse_diff_1 = __importDefault(__nccwpck_require__(2673));
+function normalizeEndLine(line, eline) {
+    return line != null && eline != null && eline < line ? undefined : eline;
+}
 function* parseRegex(input, regex, levelMap) {
     for (const match of input.matchAll(regex)) {
         const groups = match.groups ?? {};
+        const line = groups.line != null ? parseInt(groups.line) : undefined;
         yield {
             id: groups.id,
             sym: groups.sym,
             msg: groups.msg,
             level: levelMap == null ? groups.level : levelMap[groups.level],
             path: groups.path,
-            line: groups.line != null ? parseInt(groups.line) : undefined,
+            line,
             col: groups.col != null ? parseInt(groups.col) : undefined,
-            eline: groups.eline != null ? parseInt(groups.eline) : undefined,
+            eline: normalizeEndLine(line, groups.eline != null ? parseInt(groups.eline) : undefined),
             ecol: groups.ecol != null ? parseInt(groups.ecol) : undefined
         };
     }
@@ -29973,15 +29977,17 @@ function* parsePylint(input) {
         error: 'error'
     };
     for (const issue of JSON.parse(input)) {
+        const line = issue.line;
+        const endLine = issue.endLine;
         yield {
             id: issue['message-id'],
             sym: issue.symbol,
             msg: issue.message,
             level: levelMap[issue.type],
             path: issue.path,
-            line: issue.line,
+            line,
             col: issue.column != null ? issue.column + 1 : undefined,
-            eline: issue.endLine,
+            eline: normalizeEndLine(line, endLine),
             ecol: issue.endColumn != null ? issue.endColumn + 1 : undefined
         };
     }
@@ -29993,7 +29999,7 @@ function parseSarifFix(result, region) {
         return undefined;
     }
     const deleted = replacement.deletedRegion;
-    const endLine = region.endLine ?? region.startLine;
+    const endLine = normalizeEndLine(region.startLine, region.endLine) ?? region.startLine;
     if (deleted.startLine !== region.startLine || (deleted.startColumn ?? 1) !== 1) {
         return undefined;
     }
@@ -30018,7 +30024,7 @@ function* parseSarif(input) {
                 path: issue.locations?.[0]?.physicalLocation?.artifactLocation?.uri,
                 line: region?.startLine,
                 col: region?.startColumn,
-                eline: region?.endLine,
+                eline: normalizeEndLine(region?.startLine, region?.endLine),
                 ecol: region?.endColumn,
                 fix: parseSarifFix(issue, region)
             };

--- a/dist/index.js
+++ b/dist/index.js
@@ -29984,6 +29984,22 @@ function* parsePylint(input) {
         };
     }
 }
+function parseSarifFix(result, region) {
+    const replacement = result.fixes?.[0]?.artifactChanges?.[0]?.replacements?.[0];
+    const text = replacement?.insertedContent?.text;
+    if (replacement == null || text == null || region?.startLine == null) {
+        return undefined;
+    }
+    const deleted = replacement.deletedRegion;
+    const endLine = region.endLine ?? region.startLine;
+    if (deleted.startLine !== region.startLine || (deleted.startColumn ?? 1) !== 1) {
+        return undefined;
+    }
+    if (deleted.endColumn == null) {
+        return (deleted.endLine ?? deleted.startLine) === endLine ? text : undefined;
+    }
+    return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? text.replace(/\n$/, '') : undefined;
+}
 function* parseSarif(input) {
     const log = JSON.parse(input);
     for (const run of log.runs) {
@@ -29991,16 +30007,18 @@ function* parseSarif(input) {
             continue;
         }
         for (const issue of run.results) {
+            const region = issue.locations?.[0]?.physicalLocation?.region;
             yield {
                 id: issue.ruleId,
                 sym: issue.ruleIndex != null ? run.tool.driver.rules?.[issue.ruleIndex]?.name : undefined,
                 msg: issue.message.text,
                 level: issue.level,
                 path: issue.locations?.[0]?.physicalLocation?.artifactLocation?.uri,
-                line: issue.locations?.[0]?.physicalLocation?.region?.startLine,
-                col: issue.locations?.[0]?.physicalLocation?.region?.startColumn,
-                eline: issue.locations?.[0]?.physicalLocation?.region?.endLine,
-                ecol: issue.locations?.[0]?.physicalLocation?.region?.endColumn
+                line: region?.startLine,
+                col: region?.startColumn,
+                eline: region?.endLine,
+                ecol: region?.endColumn,
+                fix: parseSarifFix(issue, region)
             };
         }
     }
@@ -30035,12 +30053,13 @@ function generateSarif(issues, identifier, analysisPath) {
             rulesIndices[issue.id] = rules.length;
             rules.push({ id: issue.id, name: issue.sym });
         }
+        const uri = issue.path != null ? normalizePath(issue.path, analysisPath) : undefined;
         results.push({
             message: { text: issue.msg ?? undefined },
             locations: [
                 {
                     physicalLocation: {
-                        artifactLocation: { uri: issue.path != null ? normalizePath(issue.path, analysisPath) : undefined },
+                        artifactLocation: { uri },
                         region: issue.line != null || issue.col != null || issue.eline != null || issue.ecol != null
                             ? {
                                 startLine: issue.line ?? undefined,
@@ -30052,6 +30071,18 @@ function generateSarif(issues, identifier, analysisPath) {
                     }
                 }
             ],
+            fixes: issue.fix != null && uri != null && issue.line != null
+                ? [
+                    {
+                        artifactChanges: [
+                            {
+                                artifactLocation: { uri },
+                                replacements: [{ deletedRegion: { startLine: issue.line, endLine: issue.eline ?? issue.line }, insertedContent: { text: issue.fix } }]
+                            }
+                        ]
+                    }
+                ]
+                : undefined,
             level: issue.level ?? undefined,
             ruleId: issue.id ?? issue.sym ?? undefined,
             ruleIndex: issue.id != null ? rulesIndices[issue.id] : undefined
@@ -30072,6 +30103,14 @@ function getKnownParser(identifier) {
 }
 function getRegexParser(regex, levelMap) {
     return (input) => parseRegex(input, regex, levelMap);
+}
+function buildCommentBody(commentTag, identifier, issue) {
+    const body = `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`;
+    if (issue.fix == null) {
+        return body;
+    }
+    const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.matchAll(/`+/g), (m) => m[0].length + 1)));
+    return `${body}\n${fence}suggestion\n${issue.fix === '' ? '' : `${issue.fix}\n`}${fence}`;
 }
 async function addComments(issues, prDiff, githubToken, identifier, owner, repo, prNumber, analysisPath) {
     /* eslint camelcase: ["error", {allow: ['^pull_number$', '^comment_id$', '^start_side$', '^start_line$']}] */
@@ -30105,7 +30144,7 @@ async function addComments(issues, prDiff, githubToken, identifier, owner, repo,
             start_side: 'RIGHT',
             line: endLine,
             start_line: endLine === issue.line ? undefined : issue.line,
-            body: `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`
+            body: buildCommentBody(commentTag, identifier, issue)
         };
         (0, core_1.debug)(`Generating comment ${JSON.stringify(args)}`);
         comments.push(args);
@@ -30189,7 +30228,8 @@ async function createSummary(issues, identifier, analysisPath) {
     await core_1.summary.write();
 }
 exports._testExports = {
-    normalizePath
+    normalizePath,
+    buildCommentBody
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -29941,6 +29941,7 @@ exports.getPrDiff = getPrDiff;
 exports.parseDiffLines = parseDiffLines;
 exports.isNewIssue = isNewIssue;
 exports.isCommentableIssue = isCommentableIssue;
+exports.filterNewIssues = filterNewIssues;
 exports.failOnIssues = failOnIssues;
 exports.createSummary = createSummary;
 const github_1 = __nccwpck_require__(3228);
@@ -30285,12 +30286,12 @@ function isCommentableIssue(issue, diffLines, analysisPath) {
     const lines = diffLines[normalizePath(issue.path, analysisPath)];
     return issueLines(issue.line, issue.eline).every((line) => lines?.[line] != null);
 }
-function failOnIssues(issues, toolName, analysisPath, prDiff) {
-    let failing = [...issues];
-    if (prDiff != null) {
-        const diffLines = parseDiffLines(prDiff);
-        failing = failing.filter((issue) => isNewIssue(issue, diffLines, analysisPath));
-    }
+function filterNewIssues(issues, prDiff, analysisPath) {
+    const diffLines = parseDiffLines(prDiff);
+    return [...issues].filter((issue) => isNewIssue(issue, diffLines, analysisPath));
+}
+function failOnIssues(issues, toolName) {
+    const failing = [...issues];
     if (failing.length > 0) {
         throw new Error(`${toolName} found ${failing.length} issues`);
     }
@@ -32264,7 +32265,7 @@ async function run() {
         const comment = (0, core_1.getBooleanInput)('comment');
         const summary = (0, core_1.getBooleanInput)('summary');
         const fail = (0, core_1.getBooleanInput)('fail');
-        const failOnlyNew = (0, core_1.getBooleanInput)('failOnlyNew');
+        const onlyNew = (0, core_1.getBooleanInput)('onlyNew');
         const toolName = (0, core_1.getInput)('toolName');
         const inputFormat = (0, core_1.getInput)('inputFormat');
         const inputRegex = (0, core_1.getInput)('inputRegex');
@@ -32276,27 +32277,34 @@ async function run() {
         const raw = (0, fs_1.readFileSync)(inputFile, 'utf-8');
         const input = inputFormat === 'diff' ? raw : raw.replace(/\r/g, '');
         (0, core_1.debug)(`input: ${input}`);
-        const output = (0, bugalint_1.generateSarif)(parser(input), toolName, analysisPath);
+        const prNumber = github_1.context.payload.pull_request?.number;
+        let pullRequest;
+        const getPullRequest = async () => {
+            if (prNumber == null) {
+                throw new Error('No pull request number found.');
+            }
+            pullRequest ??= [prNumber, await (0, bugalint_1.getPrDiff)(githubToken, github_1.context.repo.owner, github_1.context.repo.repo, prNumber)];
+            return pullRequest;
+        };
+        let issues = [...parser(input)];
+        if (onlyNew) {
+            const [, prDiff] = await getPullRequest();
+            issues = (0, bugalint_1.filterNewIssues)(issues, prDiff, analysisPath);
+        }
+        const output = (0, bugalint_1.generateSarif)(issues, toolName, analysisPath);
         (0, core_1.info)(`SARIF output: ${JSON.stringify(output, null, 2)}`);
         if (sarif !== '') {
             (0, fs_1.writeFileSync)(sarif, JSON.stringify(output));
         }
-        let prDiff;
-        if (comment || (fail && failOnlyNew)) {
-            const prNumber = github_1.context.payload.pull_request?.number;
-            if (prNumber == null) {
-                throw new Error('No pull request number found.');
-            }
-            prDiff = await (0, bugalint_1.getPrDiff)(githubToken, github_1.context.repo.owner, github_1.context.repo.repo, prNumber);
-            if (comment) {
-                await (0, bugalint_1.addComments)(parser(input), prDiff, githubToken, toolName, github_1.context.repo.owner, github_1.context.repo.repo, prNumber, analysisPath);
-            }
+        if (comment) {
+            const [pullNumber, prDiff] = await getPullRequest();
+            await (0, bugalint_1.addComments)(issues, prDiff, githubToken, toolName, github_1.context.repo.owner, github_1.context.repo.repo, pullNumber, analysisPath);
         }
         if (summary) {
-            await (0, bugalint_1.createSummary)(parser(input), toolName, analysisPath);
+            await (0, bugalint_1.createSummary)(issues, toolName, analysisPath);
         }
         if (fail) {
-            (0, bugalint_1.failOnIssues)(parser(input), toolName, analysisPath, failOnlyNew ? prDiff : undefined);
+            (0, bugalint_1.failOnIssues)(issues, toolName);
         }
     }
     catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30052,6 +30052,8 @@ function* parseFormatDiff(input) {
             continue;
         }
         for (const chunk of file.chunks) {
+            const markers = chunk.changes.filter((change) => change.content.startsWith('\\'));
+            const eofNewlineAdded = markers.some((change) => change.type === 'del') && !markers.some((change) => change.type === 'add');
             const changes = chunk.changes.filter((change) => !change.content.startsWith('\\'));
             let index = 0;
             while (index < changes.length) {
@@ -30075,12 +30077,13 @@ function* parseFormatDiff(input) {
                     index++;
                 }
                 let location;
+                const terminatorAdded = eofNewlineAdded && index >= changes.length;
                 if (deleted.length > 0) {
                     const line = deleted[0].ln;
                     const eline = deleted[deleted.length - 1].ln;
                     const removed = deleted.map((change) => change.content.slice(1));
                     if (removed.length === inserted.length && removed.every((content, offset) => content === inserted[offset])) {
-                        location = { line, eline };
+                        location = terminatorAdded ? { line, eline, fix: inserted } : { line, eline };
                     }
                     else if (inserted.length === 1 && inserted[0] === '') {
                         location = borrowNeighbor(changes, start, index, inserted, { line, eline }) ?? { line, eline };
@@ -30096,6 +30099,9 @@ function* parseFormatDiff(input) {
                     index++;
                 }
                 if (location != null) {
+                    if (terminatorAdded && location.fix != null) {
+                        location = { ...location, fix: [...location.fix, ''] };
+                    }
                     yield { level: 'warning', path: filePath, ...location };
                 }
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -30243,9 +30243,18 @@ async function addComments(issues, prDiff, githubToken, identifier, owner, repo,
     await octokit.rest.pulls.createReview({ owner, repo, pull_number: prNumber, event: 'COMMENT', comments });
     (0, core_1.debug)('Sent comments');
 }
+function decodeDiff(data) {
+    if (typeof data === 'string') {
+        return data;
+    }
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+        return new TextDecoder().decode(data);
+    }
+    throw new Error(`The pull request diff was returned as ${typeof data} rather than text, so no issue can be matched against the pull request`);
+}
 async function getPrDiff(githubToken, owner, repo, prNumber) {
     const octokit = (0, github_1.getOctokit)(githubToken);
-    return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data;
+    return decodeDiff((await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data);
 }
 function parseDiffLines(diff) {
     const diffLines = {};
@@ -30323,7 +30332,8 @@ async function createSummary(issues, identifier, analysisPath) {
 }
 exports._testExports = {
     normalizePath,
-    buildCommentBody
+    buildCommentBody,
+    decodeDiff
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -30258,7 +30258,11 @@ async function getPrDiff(githubToken, owner, repo, prNumber) {
 }
 function parseDiffLines(diff) {
     const diffLines = {};
-    for (const file of (0, parse_diff_1.default)(diff)) {
+    const files = (0, parse_diff_1.default)(diff);
+    if (files.length === 0 && diff.length > 0) {
+        throw new Error('The pull request diff is not empty but no file could be parsed from it, so no issue can be matched against the pull request');
+    }
+    for (const file of files) {
         if (file.to == null) {
             continue;
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29997,9 +29997,9 @@ function parseSarifFix(result, region) {
         return undefined;
     }
     if (deleted.endColumn == null) {
-        return (deleted.endLine ?? deleted.startLine) === endLine ? text : undefined;
+        return (deleted.endLine ?? deleted.startLine) === endLine ? (text === '' ? [] : text.split('\n')) : undefined;
     }
-    return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? text.replace(/\n$/, '') : undefined;
+    return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? (text === '' ? [] : text.replace(/\n$/, '').split('\n')) : undefined;
 }
 function* parseSarif(input) {
     const log = JSON.parse(input);
@@ -30024,9 +30024,81 @@ function* parseSarif(input) {
         }
     }
 }
+function normalizeDiffLineEndings(diff) {
+    return /^(?:diff --git |@@ ).*\r$/m.test(diff) ? diff.replace(/\r\n/g, '\n') : diff;
+}
+function borrowNeighbor(changes, start, end, fix, range) {
+    const before = changes[start - 1];
+    const after = changes[end];
+    if (before?.type === 'normal') {
+        return { line: before.ln1, eline: range?.eline ?? before.ln1, fix: [before.content.slice(1), ...fix] };
+    }
+    if (after?.type === 'normal') {
+        return { line: range?.line ?? after.ln1, eline: after.ln1, fix: [...fix, after.content.slice(1)] };
+    }
+    return undefined;
+}
+function* parseFormatDiff(input) {
+    for (const file of (0, parse_diff_1.default)(normalizeDiffLineEndings(input))) {
+        const filePath = file.from ?? file.to;
+        if (filePath == null) {
+            continue;
+        }
+        for (const chunk of file.chunks) {
+            const changes = chunk.changes.filter((change) => !change.content.startsWith('\\'));
+            let index = 0;
+            while (index < changes.length) {
+                const start = index;
+                const deleted = [];
+                const inserted = [];
+                while (index < changes.length) {
+                    const change = changes[index];
+                    if (change.type !== 'del') {
+                        break;
+                    }
+                    deleted.push(change);
+                    index++;
+                }
+                while (index < changes.length) {
+                    const change = changes[index];
+                    if (change.type !== 'add') {
+                        break;
+                    }
+                    inserted.push(change.content.slice(1));
+                    index++;
+                }
+                let location;
+                if (deleted.length > 0) {
+                    const line = deleted[0].ln;
+                    const eline = deleted[deleted.length - 1].ln;
+                    const removed = deleted.map((change) => change.content.slice(1));
+                    if (removed.length === inserted.length && removed.every((content, offset) => content === inserted[offset])) {
+                        location = { line, eline };
+                    }
+                    else if (inserted.length === 1 && inserted[0] === '') {
+                        location = borrowNeighbor(changes, start, index, inserted, { line, eline }) ?? { line, eline };
+                    }
+                    else {
+                        location = { line, eline, fix: inserted };
+                    }
+                }
+                else if (inserted.length > 0) {
+                    location = borrowNeighbor(changes, start, index, inserted);
+                }
+                else {
+                    index++;
+                }
+                if (location != null) {
+                    yield { level: 'warning', path: filePath, ...location };
+                }
+            }
+        }
+    }
+}
 const knownParsers = {
     pylint: parsePylint,
     sarif: parseSarif,
+    diff: parseFormatDiff,
     mypy: (input) => parseRegex(input, /^(?<path>[^:\n]+):(?:(?<line>\d+):)?(?:(?<col>\d+):)?(?:(?<eline>\d+):)?(?:(?<ecol>\d+):)? (?<level>[^:\s]+): (?<msg>.+?)\s*(?:\[(?<id>\S+)\])?$/gm),
     flake8: (input) => parseRegex(input, /^(?<path>[^:\n]+):(?<line>\d+):(?<col>\d+): (?<id>\w\d+) (?<msg>[^\n]+)$/gm),
     mdl: (input) => parseRegex(input, /^(?<path>[^:\n]+)(?::(?<line>\d+))?(?::(?<col>\d+))? (?<id>[^/\n]+)\/(?<sym>[^\s]+) (?<msg>[^\n]+)$/gm),
@@ -30045,6 +30117,12 @@ function normalizePath(givenPath, analysisPath) {
     }
     return path_1.default.relative('.', path_1.default.join(analysisPath, givenPath)).replace(/\\/g, '/');
 }
+function* appendMessage(issues, message) {
+    for (const issue of issues) {
+        const msg = [issue.msg, message].filter((part) => part != null && part !== '').join(' ');
+        yield { ...issue, msg: msg === '' ? undefined : msg };
+    }
+}
 function generateSarif(issues, identifier, analysisPath) {
     const rulesIndices = {};
     const rules = [];
@@ -30056,7 +30134,7 @@ function generateSarif(issues, identifier, analysisPath) {
         }
         const uri = issue.path != null ? normalizePath(issue.path, analysisPath) : undefined;
         results.push({
-            message: { text: issue.msg ?? undefined },
+            message: { text: issue.msg ?? '' },
             locations: [
                 {
                     physicalLocation: {
@@ -30078,7 +30156,12 @@ function generateSarif(issues, identifier, analysisPath) {
                         artifactChanges: [
                             {
                                 artifactLocation: { uri },
-                                replacements: [{ deletedRegion: { startLine: issue.line, endLine: issue.eline ?? issue.line }, insertedContent: { text: issue.fix } }]
+                                replacements: [
+                                    {
+                                        deletedRegion: { startLine: issue.line, startColumn: 1, endLine: (issue.eline ?? issue.line) + 1, endColumn: 1 },
+                                        insertedContent: { text: issue.fix.map((line) => `${line}\n`).join('') }
+                                    }
+                                ]
                             }
                         ]
                     }
@@ -30095,23 +30178,24 @@ function generateSarif(issues, identifier, analysisPath) {
         runs: [{ tool: { driver: { name: identifier, rules } }, results }]
     };
 }
-function getKnownParser(identifier) {
+function getKnownParser(identifier, message) {
     const parser = knownParsers[identifier];
     if (parser == null) {
         throw new Error(`Unrecognized: ${identifier}`);
     }
-    return parser;
+    return (input) => appendMessage(parser(input), message);
 }
-function getRegexParser(regex, levelMap) {
-    return (input) => parseRegex(input, regex, levelMap);
+function getRegexParser(regex, message, levelMap) {
+    return (input) => appendMessage(parseRegex(input, regex, levelMap), message);
 }
 function buildCommentBody(commentTag, identifier, issue) {
-    const body = `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`;
-    if (issue.fix == null) {
+    const identifiers = `[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`;
+    const body = `${commentTag}\n${[issue.msg != null && issue.msg !== '' ? `**${issue.msg}**` : undefined, identifiers].filter((n) => n).join('\n')}`;
+    if (issue.fix == null || (issue.fix.length === 1 && issue.fix[0] === '')) {
         return body;
     }
-    const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.matchAll(/`+/g), (m) => m[0].length + 1)));
-    return `${body}\n${fence}suggestion\n${issue.fix === '' ? '' : `${issue.fix}\n`}${fence}`;
+    const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.join('\n').matchAll(/`+/g), (m) => m[0].length + 1)));
+    return `${body}\n${fence}suggestion\n${issue.fix.map((line) => `${line}\n`).join('')}${fence}`;
 }
 async function addComments(issues, prDiff, githubToken, identifier, owner, repo, prNumber, analysisPath) {
     /* eslint camelcase: ["error", {allow: ['^pull_number$', '^comment_id$', '^start_side$', '^start_line$']}] */
@@ -32167,6 +32251,12 @@ const fs_1 = __nccwpck_require__(9896);
 const github_1 = __nccwpck_require__(3228);
 const core_1 = __nccwpck_require__(7484);
 const bugalint_1 = __nccwpck_require__(8983);
+function getParser(inputFormat, inputRegex, levelMap, message) {
+    if (inputFormat === '') {
+        return (0, bugalint_1.getRegexParser)(new RegExp(inputRegex, 'gm'), message, levelMap === '' ? undefined : JSON.parse(levelMap));
+    }
+    return (0, bugalint_1.getKnownParser)(inputFormat, message);
+}
 async function run() {
     try {
         const inputFile = (0, core_1.getInput)('inputFile');
@@ -32181,10 +32271,10 @@ async function run() {
         const levelMap = (0, core_1.getInput)('levelMap');
         const analysisPath = (0, core_1.getInput)('analysisPath');
         const githubToken = (0, core_1.getInput)('githubToken');
-        const parser = inputFormat === ''
-            ? (0, bugalint_1.getRegexParser)(new RegExp(inputRegex, 'gm'), levelMap === '' ? undefined : JSON.parse(levelMap))
-            : (0, bugalint_1.getKnownParser)(inputFormat);
-        const input = (0, fs_1.readFileSync)(inputFile, 'utf-8').replace(/\r/g, '');
+        const message = (0, core_1.getInput)('message');
+        const parser = getParser(inputFormat, inputRegex, levelMap, message);
+        const raw = (0, fs_1.readFileSync)(inputFile, 'utf-8');
+        const input = inputFormat === 'diff' ? raw : raw.replace(/\r/g, '');
         (0, core_1.debug)(`input: ${input}`);
         const output = (0, bugalint_1.generateSarif)(parser(input), toolName, analysisPath);
         (0, core_1.info)(`SARIF output: ${JSON.stringify(output, null, 2)}`);

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -355,9 +355,19 @@ export async function addComments(
 
 export type DiffLines = Record<string, Record<number, boolean>>
 
+function decodeDiff(data: unknown): string {
+  if (typeof data === 'string') {
+    return data
+  }
+  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data)
+  }
+  throw new Error(`The pull request diff was returned as ${typeof data} rather than text, so no issue can be matched against the pull request`)
+}
+
 export async function getPrDiff(githubToken: string, owner: string, repo: string, prNumber: number): Promise<string> {
   const octokit = getOctokit(githubToken)
-  return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data as unknown as string
+  return decodeDiff((await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data)
 }
 
 export function parseDiffLines(diff: string): DiffLines {
@@ -441,5 +451,6 @@ export async function createSummary(issues: Iterable<Issue>, identifier: string,
 
 export const _testExports = {
   normalizePath,
-  buildCommentBody
+  buildCommentBody,
+  decodeDiff
 }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -372,7 +372,11 @@ export async function getPrDiff(githubToken: string, owner: string, repo: string
 
 export function parseDiffLines(diff: string): DiffLines {
   const diffLines: DiffLines = {}
-  for (const file of parseDiff(diff)) {
+  const files = parseDiff(diff)
+  if (files.length === 0 && diff.length > 0) {
+    throw new Error('The pull request diff is not empty but no file could be parsed from it, so no issue can be matched against the pull request')
+  }
+  for (const file of files) {
     if (file.to == null) {
       continue
     }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -402,12 +402,13 @@ export function isCommentableIssue(issue: Issue, diffLines: DiffLines, analysisP
   return issueLines(issue.line, issue.eline).every((line) => lines?.[line] != null)
 }
 
-export function failOnIssues(issues: Iterable<Issue>, toolName: string, analysisPath: string, prDiff?: string): void {
-  let failing = [...issues]
-  if (prDiff != null) {
-    const diffLines = parseDiffLines(prDiff)
-    failing = failing.filter((issue) => isNewIssue(issue, diffLines, analysisPath))
-  }
+export function filterNewIssues(issues: Iterable<Issue>, prDiff: string, analysisPath: string): Issue[] {
+  const diffLines = parseDiffLines(prDiff)
+  return [...issues].filter((issue) => isNewIssue(issue, diffLines, analysisPath))
+}
+
+export function failOnIssues(issues: Iterable<Issue>, toolName: string): void {
+  const failing = [...issues]
   if (failing.length > 0) {
     throw new Error(`${toolName} found ${failing.length} issues`)
   }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -1,4 +1,4 @@
-import type { Log, ReportingDescriptor, Result } from 'sarif'
+import type { Log, Region, ReportingDescriptor, Result } from 'sarif'
 import { getOctokit } from '@actions/github'
 import { debug, warning, summary } from '@actions/core'
 import path from 'path'
@@ -15,6 +15,7 @@ interface Issue {
   col?: number
   eline?: number
   ecol?: number
+  fix?: string
 }
 
 export type Parser = (input: string) => Generator<Issue>
@@ -59,6 +60,23 @@ function* parsePylint(input: string): Generator<Issue> {
   }
 }
 
+function parseSarifFix(result: Result, region?: Region): string | undefined {
+  const replacement = result.fixes?.[0]?.artifactChanges?.[0]?.replacements?.[0]
+  const text = replacement?.insertedContent?.text
+  if (replacement == null || text == null || region?.startLine == null) {
+    return undefined
+  }
+  const deleted = replacement.deletedRegion
+  const endLine = region.endLine ?? region.startLine
+  if (deleted.startLine !== region.startLine || (deleted.startColumn ?? 1) !== 1) {
+    return undefined
+  }
+  if (deleted.endColumn == null) {
+    return (deleted.endLine ?? deleted.startLine) === endLine ? text : undefined
+  }
+  return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? text.replace(/\n$/, '') : undefined
+}
+
 function* parseSarif(input: string): Generator<Issue> {
   const log: Log = JSON.parse(input)
   for (const run of log.runs) {
@@ -66,16 +84,18 @@ function* parseSarif(input: string): Generator<Issue> {
       continue
     }
     for (const issue of run.results) {
+      const region = issue.locations?.[0]?.physicalLocation?.region
       yield {
         id: issue.ruleId,
         sym: issue.ruleIndex != null ? run.tool.driver.rules?.[issue.ruleIndex]?.name : undefined,
         msg: issue.message.text,
         level: issue.level,
         path: issue.locations?.[0]?.physicalLocation?.artifactLocation?.uri,
-        line: issue.locations?.[0]?.physicalLocation?.region?.startLine,
-        col: issue.locations?.[0]?.physicalLocation?.region?.startColumn,
-        eline: issue.locations?.[0]?.physicalLocation?.region?.endLine,
-        ecol: issue.locations?.[0]?.physicalLocation?.region?.endColumn
+        line: region?.startLine,
+        col: region?.startColumn,
+        eline: region?.endLine,
+        ecol: region?.endColumn,
+        fix: parseSarifFix(issue, region)
       }
     }
   }
@@ -119,12 +139,13 @@ export function generateSarif(issues: Iterable<Issue>, identifier: string, analy
       rulesIndices[issue.id] = rules.length
       rules.push({ id: issue.id, name: issue.sym })
     }
+    const uri = issue.path != null ? normalizePath(issue.path, analysisPath) : undefined
     results.push({
       message: { text: issue.msg ?? undefined },
       locations: [
         {
           physicalLocation: {
-            artifactLocation: { uri: issue.path != null ? normalizePath(issue.path, analysisPath) : undefined },
+            artifactLocation: { uri },
             region:
               issue.line != null || issue.col != null || issue.eline != null || issue.ecol != null
                 ? {
@@ -137,6 +158,19 @@ export function generateSarif(issues: Iterable<Issue>, identifier: string, analy
           }
         }
       ],
+      fixes:
+        issue.fix != null && uri != null && issue.line != null
+          ? [
+              {
+                artifactChanges: [
+                  {
+                    artifactLocation: { uri },
+                    replacements: [{ deletedRegion: { startLine: issue.line, endLine: issue.eline ?? issue.line }, insertedContent: { text: issue.fix } }]
+                  }
+                ]
+              }
+            ]
+          : undefined,
       level: issue.level ?? undefined,
       ruleId: issue.id ?? issue.sym ?? undefined,
       ruleIndex: issue.id != null ? rulesIndices[issue.id] : undefined
@@ -159,6 +193,15 @@ export function getKnownParser(identifier: string): Parser {
 
 export function getRegexParser(regex: RegExp, levelMap?: Record<string, Result.level>): Parser {
   return (input: string) => parseRegex(input, regex, levelMap)
+}
+
+function buildCommentBody(commentTag: string, identifier: string, issue: Issue): string {
+  const body = `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`
+  if (issue.fix == null) {
+    return body
+  }
+  const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.matchAll(/`+/g), (m) => m[0].length + 1)))
+  return `${body}\n${fence}suggestion\n${issue.fix === '' ? '' : `${issue.fix}\n`}${fence}`
 }
 
 export async function addComments(
@@ -206,7 +249,7 @@ export async function addComments(
       start_side: 'RIGHT',
       line: endLine,
       start_line: endLine === issue.line ? undefined : issue.line,
-      body: `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`
+      body: buildCommentBody(commentTag, identifier, issue)
     }
     debug(`Generating comment ${JSON.stringify(args)}`)
     comments.push(args)
@@ -297,5 +340,6 @@ export async function createSummary(issues: Iterable<Issue>, identifier: string,
 }
 
 export const _testExports = {
-  normalizePath
+  normalizePath,
+  buildCommentBody
 }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -20,18 +20,23 @@ interface Issue {
 
 export type Parser = (input: string) => Generator<Issue>
 
+function normalizeEndLine(line?: number, eline?: number): number | undefined {
+  return line != null && eline != null && eline < line ? undefined : eline
+}
+
 function* parseRegex(input: string, regex: RegExp, levelMap?: Record<string, Result.level>): Generator<Issue> {
   for (const match of input.matchAll(regex)) {
     const groups = match.groups ?? {}
+    const line = groups.line != null ? parseInt(groups.line) : undefined
     yield {
       id: groups.id,
       sym: groups.sym,
       msg: groups.msg,
       level: levelMap == null ? (groups.level as Result.level) : levelMap[groups.level],
       path: groups.path,
-      line: groups.line != null ? parseInt(groups.line) : undefined,
+      line,
       col: groups.col != null ? parseInt(groups.col) : undefined,
-      eline: groups.eline != null ? parseInt(groups.eline) : undefined,
+      eline: normalizeEndLine(line, groups.eline != null ? parseInt(groups.eline) : undefined),
       ecol: groups.ecol != null ? parseInt(groups.ecol) : undefined
     }
   }
@@ -46,15 +51,17 @@ function* parsePylint(input: string): Generator<Issue> {
     error: 'error'
   }
   for (const issue of JSON.parse(input)) {
+    const line: number | undefined = issue.line
+    const endLine: number | undefined = issue.endLine
     yield {
       id: issue['message-id'],
       sym: issue.symbol,
       msg: issue.message,
       level: levelMap[issue.type],
       path: issue.path,
-      line: issue.line,
+      line,
       col: issue.column != null ? issue.column + 1 : undefined,
-      eline: issue.endLine,
+      eline: normalizeEndLine(line, endLine),
       ecol: issue.endColumn != null ? issue.endColumn + 1 : undefined
     }
   }
@@ -67,7 +74,7 @@ function parseSarifFix(result: Result, region?: Region): string[] | undefined {
     return undefined
   }
   const deleted = replacement.deletedRegion
-  const endLine = region.endLine ?? region.startLine
+  const endLine = normalizeEndLine(region.startLine, region.endLine) ?? region.startLine
   if (deleted.startLine !== region.startLine || (deleted.startColumn ?? 1) !== 1) {
     return undefined
   }
@@ -93,7 +100,7 @@ function* parseSarif(input: string): Generator<Issue> {
         path: issue.locations?.[0]?.physicalLocation?.artifactLocation?.uri,
         line: region?.startLine,
         col: region?.startColumn,
-        eline: region?.endLine,
+        eline: normalizeEndLine(region?.startLine, region?.endLine),
         ecol: region?.endColumn,
         fix: parseSarifFix(issue, region)
       }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -137,6 +137,8 @@ function* parseFormatDiff(input: string): Generator<Issue> {
       continue
     }
     for (const chunk of file.chunks) {
+      const markers = chunk.changes.filter((change) => change.content.startsWith('\\'))
+      const eofNewlineAdded = markers.some((change) => change.type === 'del') && !markers.some((change) => change.type === 'add')
       const changes = chunk.changes.filter((change) => !change.content.startsWith('\\'))
       let index = 0
       while (index < changes.length) {
@@ -160,12 +162,13 @@ function* parseFormatDiff(input: string): Generator<Issue> {
           index++
         }
         let location: Pick<Issue, 'line' | 'eline' | 'fix'> | undefined
+        const terminatorAdded = eofNewlineAdded && index >= changes.length
         if (deleted.length > 0) {
           const line = deleted[0].ln
           const eline = deleted[deleted.length - 1].ln
           const removed = deleted.map((change) => change.content.slice(1))
           if (removed.length === inserted.length && removed.every((content, offset) => content === inserted[offset])) {
-            location = { line, eline }
+            location = terminatorAdded ? { line, eline, fix: inserted } : { line, eline }
           } else if (inserted.length === 1 && inserted[0] === '') {
             location = borrowNeighbor(changes, start, index, inserted, { line, eline }) ?? { line, eline }
           } else {
@@ -177,6 +180,9 @@ function* parseFormatDiff(input: string): Generator<Issue> {
           index++
         }
         if (location != null) {
+          if (terminatorAdded && location.fix != null) {
+            location = { ...location, fix: [...location.fix, ''] }
+          }
           yield { level: 'warning', path: filePath, ...location }
         }
       }

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -15,7 +15,7 @@ interface Issue {
   col?: number
   eline?: number
   ecol?: number
-  fix?: string
+  fix?: string[]
 }
 
 export type Parser = (input: string) => Generator<Issue>
@@ -60,7 +60,7 @@ function* parsePylint(input: string): Generator<Issue> {
   }
 }
 
-function parseSarifFix(result: Result, region?: Region): string | undefined {
+function parseSarifFix(result: Result, region?: Region): string[] | undefined {
   const replacement = result.fixes?.[0]?.artifactChanges?.[0]?.replacements?.[0]
   const text = replacement?.insertedContent?.text
   if (replacement == null || text == null || region?.startLine == null) {
@@ -72,9 +72,9 @@ function parseSarifFix(result: Result, region?: Region): string | undefined {
     return undefined
   }
   if (deleted.endColumn == null) {
-    return (deleted.endLine ?? deleted.startLine) === endLine ? text : undefined
+    return (deleted.endLine ?? deleted.startLine) === endLine ? (text === '' ? [] : text.split('\n')) : undefined
   }
-  return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? text.replace(/\n$/, '') : undefined
+  return deleted.endColumn === 1 && deleted.endLine === endLine + 1 ? (text === '' ? [] : text.replace(/\n$/, '').split('\n')) : undefined
 }
 
 function* parseSarif(input: string): Generator<Issue> {
@@ -101,9 +101,86 @@ function* parseSarif(input: string): Generator<Issue> {
   }
 }
 
+function normalizeDiffLineEndings(diff: string): string {
+  return /^(?:diff --git |@@ ).*\r$/m.test(diff) ? diff.replace(/\r\n/g, '\n') : diff
+}
+
+function borrowNeighbor(
+  changes: parseDiff.Change[],
+  start: number,
+  end: number,
+  fix: string[],
+  range?: Pick<Issue, 'line' | 'eline'>
+): Pick<Issue, 'line' | 'eline' | 'fix'> | undefined {
+  const before = changes[start - 1]
+  const after = changes[end]
+  if (before?.type === 'normal') {
+    return { line: before.ln1, eline: range?.eline ?? before.ln1, fix: [before.content.slice(1), ...fix] }
+  }
+  if (after?.type === 'normal') {
+    return { line: range?.line ?? after.ln1, eline: after.ln1, fix: [...fix, after.content.slice(1)] }
+  }
+  return undefined
+}
+
+function* parseFormatDiff(input: string): Generator<Issue> {
+  for (const file of parseDiff(normalizeDiffLineEndings(input))) {
+    const filePath = file.from ?? file.to
+    if (filePath == null) {
+      continue
+    }
+    for (const chunk of file.chunks) {
+      const changes = chunk.changes.filter((change) => !change.content.startsWith('\\'))
+      let index = 0
+      while (index < changes.length) {
+        const start = index
+        const deleted: parseDiff.DeleteChange[] = []
+        const inserted: string[] = []
+        while (index < changes.length) {
+          const change = changes[index]
+          if (change.type !== 'del') {
+            break
+          }
+          deleted.push(change)
+          index++
+        }
+        while (index < changes.length) {
+          const change = changes[index]
+          if (change.type !== 'add') {
+            break
+          }
+          inserted.push(change.content.slice(1))
+          index++
+        }
+        let location: Pick<Issue, 'line' | 'eline' | 'fix'> | undefined
+        if (deleted.length > 0) {
+          const line = deleted[0].ln
+          const eline = deleted[deleted.length - 1].ln
+          const removed = deleted.map((change) => change.content.slice(1))
+          if (removed.length === inserted.length && removed.every((content, offset) => content === inserted[offset])) {
+            location = { line, eline }
+          } else if (inserted.length === 1 && inserted[0] === '') {
+            location = borrowNeighbor(changes, start, index, inserted, { line, eline }) ?? { line, eline }
+          } else {
+            location = { line, eline, fix: inserted }
+          }
+        } else if (inserted.length > 0) {
+          location = borrowNeighbor(changes, start, index, inserted)
+        } else {
+          index++
+        }
+        if (location != null) {
+          yield { level: 'warning', path: filePath, ...location }
+        }
+      }
+    }
+  }
+}
+
 const knownParsers: Record<string, Parser> = {
   pylint: parsePylint,
   sarif: parseSarif,
+  diff: parseFormatDiff,
   mypy: (input: string) =>
     parseRegex(
       input,
@@ -129,6 +206,13 @@ function normalizePath(givenPath: string, analysisPath: string): string {
   return path.relative('.', path.join(analysisPath, givenPath)).replace(/\\/g, '/')
 }
 
+function* appendMessage(issues: Generator<Issue>, message: string): Generator<Issue> {
+  for (const issue of issues) {
+    const msg = [issue.msg, message].filter((part) => part != null && part !== '').join(' ')
+    yield { ...issue, msg: msg === '' ? undefined : msg }
+  }
+}
+
 export function generateSarif(issues: Iterable<Issue>, identifier: string, analysisPath: string): Log {
   const rulesIndices: Record<string, number> = {}
   const rules: ReportingDescriptor[] = []
@@ -141,7 +225,7 @@ export function generateSarif(issues: Iterable<Issue>, identifier: string, analy
     }
     const uri = issue.path != null ? normalizePath(issue.path, analysisPath) : undefined
     results.push({
-      message: { text: issue.msg ?? undefined },
+      message: { text: issue.msg ?? '' },
       locations: [
         {
           physicalLocation: {
@@ -165,7 +249,12 @@ export function generateSarif(issues: Iterable<Issue>, identifier: string, analy
                 artifactChanges: [
                   {
                     artifactLocation: { uri },
-                    replacements: [{ deletedRegion: { startLine: issue.line, endLine: issue.eline ?? issue.line }, insertedContent: { text: issue.fix } }]
+                    replacements: [
+                      {
+                        deletedRegion: { startLine: issue.line, startColumn: 1, endLine: (issue.eline ?? issue.line) + 1, endColumn: 1 },
+                        insertedContent: { text: issue.fix.map((line) => `${line}\n`).join('') }
+                      }
+                    ]
                   }
                 ]
               }
@@ -183,25 +272,26 @@ export function generateSarif(issues: Iterable<Issue>, identifier: string, analy
   }
 }
 
-export function getKnownParser(identifier: string): Parser {
+export function getKnownParser(identifier: string, message: string): Parser {
   const parser = knownParsers[identifier]
   if (parser == null) {
     throw new Error(`Unrecognized: ${identifier}`)
   }
-  return parser
+  return (input: string) => appendMessage(parser(input), message)
 }
 
-export function getRegexParser(regex: RegExp, levelMap?: Record<string, Result.level>): Parser {
-  return (input: string) => parseRegex(input, regex, levelMap)
+export function getRegexParser(regex: RegExp, message: string, levelMap?: Record<string, Result.level>): Parser {
+  return (input: string) => appendMessage(parseRegex(input, regex, levelMap), message)
 }
 
 function buildCommentBody(commentTag: string, identifier: string, issue: Issue): string {
-  const body = `${commentTag}\n**${issue.msg}**\n[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`
-  if (issue.fix == null) {
+  const identifiers = `[${[issue.level, identifier, issue.id, issue.sym].filter((n) => n).join(':')}]`
+  const body = `${commentTag}\n${[issue.msg != null && issue.msg !== '' ? `**${issue.msg}**` : undefined, identifiers].filter((n) => n).join('\n')}`
+  if (issue.fix == null || (issue.fix.length === 1 && issue.fix[0] === '')) {
     return body
   }
-  const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.matchAll(/`+/g), (m) => m[0].length + 1)))
-  return `${body}\n${fence}suggestion\n${issue.fix === '' ? '' : `${issue.fix}\n`}${fence}`
+  const fence = '`'.repeat(Math.max(3, ...Array.from(issue.fix.join('\n').matchAll(/`+/g), (m) => m[0].length + 1)))
+  return `${body}\n${fence}suggestion\n${issue.fix.map((line) => `${line}\n`).join('')}${fence}`
 }
 
 export async function addComments(

--- a/src/bugalint.ts
+++ b/src/bugalint.ts
@@ -228,13 +228,13 @@ export async function addComments(
     }
   }
 
-  const addedLines = parseAddedLines(prDiff)
+  const diffLines = parseDiffLines(prDiff)
 
   const comments = []
   for (const issue of issues) {
     debug(`Processing issue on ${issue.path}:${issue.line}`)
-    if (!isNewIssue(issue, addedLines, analysisPath)) {
-      debug(`Skipping issue on ${issue.path}:${issue.line} because it's not in the PR diff`)
+    if (!isCommentableIssue(issue, diffLines, analysisPath)) {
+      debug(`Skipping issue on ${issue.path}:${issue.line} because it is not on lines the pull request diff shows`)
       continue
     }
     if (comments.length >= 50) {
@@ -263,51 +263,60 @@ export async function addComments(
   debug('Sent comments')
 }
 
-export type AddedLines = Record<string, Record<number, boolean>>
+export type DiffLines = Record<string, Record<number, boolean>>
 
 export async function getPrDiff(githubToken: string, owner: string, repo: string, prNumber: number): Promise<string> {
   const octokit = getOctokit(githubToken)
   return (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber, mediaType: { format: 'diff' } })).data as unknown as string
 }
 
-export function parseAddedLines(diff: string): AddedLines {
-  const addedLines: AddedLines = {}
+export function parseDiffLines(diff: string): DiffLines {
+  const diffLines: DiffLines = {}
   for (const file of parseDiff(diff)) {
     if (file.to == null) {
       continue
     }
     debug(`PR file diff: ${file.to} (${file.chunks.length} chunks)`)
-    addedLines[file.to] = {}
+    diffLines[file.to] = {}
     for (const chunk of file.chunks) {
       for (const change of chunk.changes) {
         if (change.type === 'add') {
-          addedLines[file.to][change?.ln] = true
+          diffLines[file.to][change.ln] = true
+        } else if (change.type === 'normal') {
+          diffLines[file.to][change.ln2] = false
         }
       }
     }
   }
-  debug(`addedLines: ${JSON.stringify(addedLines)}`)
-  return addedLines
+  debug(`diffLines: ${JSON.stringify(diffLines)}`)
+  return diffLines
 }
 
-export function isNewIssue(issue: Issue, addedLines: AddedLines, analysisPath: string): issue is Issue & Required<Pick<Issue, 'path' | 'line'>> {
+function issueLines(line: number, eline?: number): number[] {
+  return Array.from({ length: (eline ?? line) - line + 1 }, (_, offset) => line + offset)
+}
+
+export function isNewIssue(issue: Issue, diffLines: DiffLines, analysisPath: string): issue is Issue & Required<Pick<Issue, 'path' | 'line'>> {
   if (issue.path == null || issue.line == null) {
     return false
   }
-  const normalized = normalizePath(issue.path, analysisPath)
-  for (let line = issue.line; line <= (issue.eline ?? issue.line); line++) {
-    if (!addedLines?.[normalized]?.[line]) {
-      return false
-    }
+  const lines: Record<number, boolean> | undefined = diffLines[normalizePath(issue.path, analysisPath)]
+  return issueLines(issue.line, issue.eline).some((line) => lines?.[line] ?? false)
+}
+
+export function isCommentableIssue(issue: Issue, diffLines: DiffLines, analysisPath: string): issue is Issue & Required<Pick<Issue, 'path' | 'line'>> {
+  if (!isNewIssue(issue, diffLines, analysisPath)) {
+    return false
   }
-  return true
+  const lines: Record<number, boolean> | undefined = diffLines[normalizePath(issue.path, analysisPath)]
+  return issueLines(issue.line, issue.eline).every((line) => lines?.[line] != null)
 }
 
 export function failOnIssues(issues: Iterable<Issue>, toolName: string, analysisPath: string, prDiff?: string): void {
   let failing = [...issues]
   if (prDiff != null) {
-    const addedLines = parseAddedLines(prDiff)
-    failing = failing.filter((issue) => isNewIssue(issue, addedLines, analysisPath))
+    const diffLines = parseDiffLines(prDiff)
+    failing = failing.filter((issue) => isNewIssue(issue, diffLines, analysisPath))
   }
   if (failing.length > 0) {
     throw new Error(`${toolName} found ${failing.length} issues`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,17 @@ import { readFileSync, writeFileSync } from 'fs'
 import type { Result } from 'sarif'
 import { context } from '@actions/github'
 import { getInput, getBooleanInput, debug, info, setFailed } from '@actions/core'
-import { generateSarif, getKnownParser, getRegexParser, getPrDiff, addComments, createSummary, failOnIssues, type Parser } from '../src/bugalint'
+import {
+  generateSarif,
+  getKnownParser,
+  getRegexParser,
+  getPrDiff,
+  addComments,
+  createSummary,
+  failOnIssues,
+  filterNewIssues,
+  type Parser
+} from '../src/bugalint'
 
 function getParser(inputFormat: string, inputRegex: string, levelMap: string, message: string): Parser {
   if (inputFormat === '') {
@@ -18,7 +28,7 @@ export async function run(): Promise<void> {
     const comment: boolean = getBooleanInput('comment')
     const summary: boolean = getBooleanInput('summary')
     const fail: boolean = getBooleanInput('fail')
-    const failOnlyNew: boolean = getBooleanInput('failOnlyNew')
+    const onlyNew: boolean = getBooleanInput('onlyNew')
     const toolName: string = getInput('toolName')
     const inputFormat: string = getInput('inputFormat')
     const inputRegex: string = getInput('inputRegex')
@@ -27,31 +37,41 @@ export async function run(): Promise<void> {
     const githubToken: string = getInput('githubToken')
     const message: string = getInput('message')
 
-    const parser: Parser = getParser(inputFormat, inputRegex, levelMap, message)
+    const parser = getParser(inputFormat, inputRegex, levelMap, message)
     const raw = readFileSync(inputFile, 'utf-8')
     const input = inputFormat === 'diff' ? raw : raw.replace(/\r/g, '')
     debug(`input: ${input}`)
-    const output = generateSarif(parser(input), toolName, analysisPath)
+
+    const prNumber = context.payload.pull_request?.number
+    let pullRequest: [number, string] | undefined
+    const getPullRequest = async (): Promise<[number, string]> => {
+      if (prNumber == null) {
+        throw new Error('No pull request number found.')
+      }
+      pullRequest ??= [prNumber, await getPrDiff(githubToken, context.repo.owner, context.repo.repo, prNumber)]
+      return pullRequest
+    }
+
+    let issues = [...parser(input)]
+    if (onlyNew) {
+      const [, prDiff] = await getPullRequest()
+      issues = filterNewIssues(issues, prDiff, analysisPath)
+    }
+
+    const output = generateSarif(issues, toolName, analysisPath)
     info(`SARIF output: ${JSON.stringify(output, null, 2)}`)
     if (sarif !== '') {
       writeFileSync(sarif, JSON.stringify(output))
     }
-    let prDiff: string | undefined
-    if (comment || (fail && failOnlyNew)) {
-      const prNumber = context.payload.pull_request?.number
-      if (prNumber == null) {
-        throw new Error('No pull request number found.')
-      }
-      prDiff = await getPrDiff(githubToken, context.repo.owner, context.repo.repo, prNumber)
-      if (comment) {
-        await addComments(parser(input), prDiff, githubToken, toolName, context.repo.owner, context.repo.repo, prNumber, analysisPath)
-      }
+    if (comment) {
+      const [pullNumber, prDiff] = await getPullRequest()
+      await addComments(issues, prDiff, githubToken, toolName, context.repo.owner, context.repo.repo, pullNumber, analysisPath)
     }
     if (summary) {
-      await createSummary(parser(input), toolName, analysisPath)
+      await createSummary(issues, toolName, analysisPath)
     }
     if (fail) {
-      failOnIssues(parser(input), toolName, analysisPath, failOnlyNew ? prDiff : undefined)
+      failOnIssues(issues, toolName)
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,13 @@ import { context } from '@actions/github'
 import { getInput, getBooleanInput, debug, info, setFailed } from '@actions/core'
 import { generateSarif, getKnownParser, getRegexParser, getPrDiff, addComments, createSummary, failOnIssues, type Parser } from '../src/bugalint'
 
+function getParser(inputFormat: string, inputRegex: string, levelMap: string, message: string): Parser {
+  if (inputFormat === '') {
+    return getRegexParser(new RegExp(inputRegex, 'gm'), message, levelMap === '' ? undefined : (JSON.parse(levelMap) as Record<string, Result.level>))
+  }
+  return getKnownParser(inputFormat, message)
+}
+
 export async function run(): Promise<void> {
   try {
     const inputFile: string = getInput('inputFile')
@@ -18,12 +25,11 @@ export async function run(): Promise<void> {
     const levelMap: string = getInput('levelMap')
     const analysisPath: string = getInput('analysisPath')
     const githubToken: string = getInput('githubToken')
+    const message: string = getInput('message')
 
-    const parser: Parser =
-      inputFormat === ''
-        ? getRegexParser(new RegExp(inputRegex, 'gm'), levelMap === '' ? undefined : (JSON.parse(levelMap) as Record<string, Result.level>))
-        : getKnownParser(inputFormat)
-    const input = readFileSync(inputFile, 'utf-8').replace(/\r/g, '')
+    const parser: Parser = getParser(inputFormat, inputRegex, levelMap, message)
+    const raw = readFileSync(inputFile, 'utf-8')
+    const input = inputFormat === 'diff' ? raw : raw.replace(/\r/g, '')
     debug(`input: ${input}`)
     const output = generateSarif(parser(input), toolName, analysisPath)
     info(`SARIF output: ${JSON.stringify(output, null, 2)}`)


### PR DESCRIPTION
Adds native support for GitHub *suggested changes*, driven by standard SARIF `fixes`, plus a `diff` input format that produces them from any formatter that can rewrite files in place.

Motivation is a clang-format lint over a large C++ repo: clang-format knows the exact fix for every violation, but bugalint had no way to express one. Embedding a suggestion block in the message does not work — the body template is `**${msg}**`, so a message ending in a fence produces `` ```** ``, the fence never closes, and GitHub swallows the rest of the body into the suggested code.

## `feat: render SARIF fixes as GitHub suggestions`

- `Issue` gains an optional `fix`, read by `parseSarif` from `fixes[0].artifactChanges[0].replacements[0].insertedContent` and re-emitted by `generateSarif`, so the parse/generate round trip stays lossless and code scanning receives the fix too.
- `addComments` appends the suggestion block *after* the identifier line. Being last is what makes the body well formed — nothing follows the closing fence.
- An empty `insertedContent.text` renders as an empty suggestion, which is how GitHub expresses a deletion. Rendering it as a block containing one blank line would instead leave a stray blank line behind on every deletion.
- The fence grows past the longest backtick run in the fix, so code containing a fence still renders.

The fix's `deletedRegion` is what decides whether the inserted text ends with a line terminator, so taking the text verbatim would be wrong in one direction or the other. Per the SARIF specification an absent `endColumn` means the end of the text of `endLine`, so the two usual spellings of a whole line replacement differ by exactly one line terminator:

| `deletedRegion` for lines 3–4 | covers | `insertedContent.text` |
| --- | --- | --- |
| `{startLine: 3, endLine: 4}` | the text of both lines, not the terminator ending line 4 | must not end with a newline |
| `{startLine: 3, startColumn: 1, endLine: 5, endColumn: 1}` | the same lines including that terminator | must end with a newline |

So the second form has its single trailing newline removed and the first is taken verbatim. Trimming unconditionally would drop a meaningful trailing empty line; not trimming at all appends a spurious one. Both are expressible, and a producer using either spelling gets the same suggestion.

The region is also checked against the result's own region, and a fix is ignored when it cannot be rendered as a whole line replacement of the anchored lines. Without that, an ESLint- or Semgrep-style character precise fix — say `deletedRegion` covering columns 5–7 with text `===` — would render as a suggestion replacing the *entire line* with `===`. The issue is still commented on, just without a suggestion.

## `feat: match multi line issues that partially overlap added lines`

`isNewIssue` required *every* line of the range to be an added line. Formatting fixes routinely span a continuation line the PR did not touch, and those were silently dropped from both the comments and the failure count — in the repo that motivated this, 35% of results span three or more lines.

It now matches when *any* line in the range was added. `parseAddedLines` becomes `parseDiffLines` and records context lines too (`true` = added, `false` = context). That keeps the same shape and a single pass over the diff, while enabling the second check: `addComments` now skips issues spanning a line outside the diff. That guard is not optional — all comments go out in one `createReview`, so a single out-of-hunk anchor returns 422 and loses the whole batch.

**Behaviour change worth your attention:** this affects `onlyNew` (`failOnlyNew` at this point in the branch) for every consumer, not only SARIF ones, since a multi line issue that partially overlaps added lines now counts. I left it as a plain `feat` — say the word if you would rather it be breaking, or want it split into its own PR.

## `feat: support converting a formatter diff to suggestions`

The two commits above only let a linter that already speaks SARIF carry a fix. This one removes that requirement: a new `diff` input format reads the output of `git diff`, so `clang-format -i` followed by `git diff` is enough to get suggested changes, with no bespoke converter in between. Detecting changes on disk and turning them into SARIF is squarely bugalint's job, and the suggestion machinery was already parser agnostic, so this is one `Parser` plus wiring. Everything downstream — the SARIF uploaded to code scanning, the job summary, `onlyNew` — works unchanged.

Three things it has to get right:

- **One issue per contiguous run of changed lines, not per hunk.** `git diff` prints three lines of context around each change; anchoring on the hunk would widen every range by up to six lines and push it outside the pull request's diff. One real file in the consuming repo has 38 hunks but 56 change runs.
- **Anchoring on the old side.** The formatted text exists nowhere in the pull request. The old side is the committed file, which is what GitHub shows and what a comment can attach to, so `line`/`eline` come from `del.ln` and `normal.ln1`, and the new side becomes the fix.
- **Runs that only add lines.** They have no old line to anchor to, and a suggestion cannot attach to nothing, so the range is extended to a neighbouring line — the preceding one, or the following one at the top of a file — whose content is repeated in the fix.

Two details that only show up on real input. `git diff` emits `\ No newline at end of file` as an ordinary change with a duplicated line number, so it has to be filtered or the marker text lands inside the suggestion. And `index.ts` stripped every `\r` before parsing, which is right for the existing formats but not here, where a carriage return can be content: rewriting CRLF to LF would make a reviewer clicking *Commit suggestion* commit mixed line endings. Whether a diff is CRLF terminated or merely describes CRLF content is decided by looking at whether git's own header lines end with `\r`, which is unambiguous and handles both together.

A new `message` input is appended to the message of every issue, and so becomes the whole message of a format like this one that carries neither a message nor a level. It is empty by default, since a message that applies to every issue equally is workflow-specific and a generic default would just be noise on every comment.

Worth knowing: a formatter that crashes without writing anything produces an empty diff, which is indistinguishable from a clean run. The workflow has to make the formatter step fail by itself — noted in the README.

### Blanking a line is not deleting it

The first version of this held a fix as a single string, and a consuming session running the shipped bundle over a real repository found what that costs. The lines to substitute were recovered by splitting on newlines — and `[''].join('\n')` is `''`, exactly like `[].join('\n')`. An empty fix renders as an empty suggestion, which GitHub applies as a **deletion**. A formatter stripping the whitespace of a blank line produces precisely that diff (`-␠␠␠␠` / `+`), so the suggestion *removed* the line instead of blanking it.

The oracle is the convincing part: applying every suggestion and comparing byte-for-byte against the formatter's own output gave **707 of 743 files correct with the string representation, and 743 of 743 with a list of lines** — the 36 failures being exactly the files containing those 51 blocks.

Worth saying why 0.6% of results justified a representation change. A formatter never *inserts* blank lines, so a reviewer who applies the bad suggestion is left with a file that is still clean by the formatter's own standard: the check goes green, there is no oscillation to notice and no red build, and the separator line is simply gone. Nothing downstream can catch it. A suggestion that quietly does something other than what it renders is the one failure mode this feature cannot have.

So `Issue.fix` is a `string[]`: no lines means delete, one empty line means blank. Nothing about the input formats changes, and the action's inputs are untouched. The SARIF input path had the identical defect and is closed by the same change — a producer expressing "blank these lines" writes a fix whose text is a single line terminator over a terminator-inclusive `deletedRegion`, and stripping that trailing newline arrives at the empty string as well.

That has one consequence for the SARIF written out. The two `deletedRegion` spellings are not equally expressive here — the terminator-exclusive one writes both "delete" and "blank" as an empty text, so only the terminator-inclusive one can carry the distinction. Emitted fixes therefore use it uniformly, which is what makes reading back a bugalint-generated SARIF lossless. I verified that directly: every fixture, re-parsed and re-generated, is deep-equal to itself. Both spellings are still accepted on input, and the README says plainly that a producer restricted to the terminator-exclusive one has to widen the range to express a blank line.

### GitHub cannot render a one-blank-line suggestion either

Distinguishing the two in `Issue.fix` and in the emitted SARIF does not, on its own, fix what the reviewer sees, because GitHub's own suggestion renderer has the same bug — and I only learned that by measuring it. Two sessions posted suggestion comments on real pull requests, varying only the fence content, and read the rendered `body_html` back. Independently reproduced on this PR:

| fence content | addition rows drawn |
| --- | --- |
| `""` (delete) | 0 |
| `"\n"` (blank one line) | **0 — identical to a deletion** |
| `"\n\n"` | 2 |
| `" \n"` | 1 |
| `"\nint x;\n"` | 2 |

So it is not a renderer that cannot draw empty rows — rows 3 and 5 each draw one. One rule fits every point: **strip one trailing newline, then test for empty.** `"\n"` collapses onto `""` and the block is treated as having no lines at all. That is the same order-of-operations mistake the SARIF reader had to avoid; GitHub's copy is in their renderer, so the conclusion is structural rather than a bug on our side: the ```suggestion wire format **cannot express "replace these lines with exactly one empty line"**. No encoding fixes it. I checked the stored bytes at both ends before accepting that — GitHub keeps the extra `0a` faithfully, so nothing is lost in transit, and our producer was already correct.

The consequence is that the narrow suggestion is not merely unhelpful, it is *wrong*: it renders as deleting a line the formatter asked to keep, indistinguishably from a genuine deletion. So a fix that is exactly one empty line is extended to a neighbouring line, preferring the preceding one — the same borrow a run of pure insertions already needs, and shared with it, so there is exactly one place where an anchor can move. The borrowed line is a context line of the formatter's own diff, and GitHub's hunks carry three lines of context, so it falls outside the pull request diff essentially only when the blanked line is the first line of the file — where there is no preceding line to borrow anyway and it extends forward instead. When there is neither, as in a file that is a single blank line, the issue is reported without a fix, which is the right end of the trade: *possibly dropped* beats *actively wrong*.

This is also why the list representation is load-bearing rather than superseded: you cannot decide to widen if you cannot tell `[]` from `['']`. Every other shape is untouched — `['x','']`, `['','x']` and `['','']` all render correctly, and are covered. The same guard sits at the comment boundary, so a lone-newline fix arriving through the SARIF input path cannot render as a deletion either.

What I could not measure is what *Apply* writes, since no API applies a suggestion — that needs a human click. It does not change the decision: the rendered preview is all a reviewer sees before approving, and it currently reads "delete this line".

### A change of a line terminator alone yields no fix

The other half of the end-of-file marker handling, found while checking a claim about how reviewdog treats the same case.

A formatter normally terminates the last line of a file that does not end with a newline. When that is the *only* thing it changes, `git diff` still prints a deleted and an added line, because the bytes differ — but the two lines have identical text:

```diff
-  int last = 0;
\ No newline at end of file
+  int last = 0;
```

Filtering the marker therefore leaves a fix that replaces a line with itself. GitHub renders it happily, and clicking *Commit suggestion* cannot change anything, so the comment returns on the next run and no reviewer can ever resolve it by clicking. I confirmed it by running the shipped bundle on that diff: the emitted `insertedContent.text` came out byte-identical to the line it replaced.

A run whose old and new lines are identical therefore yields the issue *without* a fix. The line is still reported and the step still fails; the reviewer runs the formatter instead of clicking. That is deliberately the option that assumes nothing about how GitHub applies a suggestion.

Worth being plain about what that costs, because it is not free. The comment sits on a line that is visibly formatted correctly, carries no suggestion, and gives no hint that the difference is an invisible missing newline at the end of the file. In diff mode the message is workflow level and identical for every result, so nothing distinguishes this case from an ordinary one, and a reviewer could reasonably read it as a false positive. Whether the answer is to emit a suggestion after all or to let the message carry the explanation depends on the same unmeasured thing — whether GitHub terminates the last line of an applied suggestion — so it is left until that is known rather than guessed. I have not put a frequency on it either: the affected set is files where the terminator is the *only* difference, which is a subset of the files lacking one, and nobody has counted it.

reviewdog instead appends an empty line to the suggestion, on the theory that GitHub reads it as the missing terminator rather than as a new blank line (`parser/diff.go`, `hunk.EOFNewline == diff.LineAdded`). That would make the comment resolvable by clicking, and it may well be right — but the evidence for it is one manual observation, linked from a source comment that hedges itself with "this is known to work with GitHub review suggestions, at least". There is a test, `TestSuggestionContainsEofNewline`, and it is worth being precise about what it pins: that reviewdog emits the trailing blank line, not that GitHub reads that blank line as a terminator. No API applies a suggestion, so the second half is not testable by anyone. Two of the bugs fixed in this PR came from exactly that kind of plausible assumption, so this sidesteps the bet rather than taking the other side of it. Say the word if you would rather have it.

## `feat!: filter out old issues before generating any output`

The only breaking commit here, and the one to look at first.

`failOnlyNew` narrowed the failure and nothing else. A run with it set still wrote every issue to the SARIF, the log, the summary and the comments — only the exit code reflected the filtering, and the same input was parsed four separate times to do it. That split gets worse with the commits above: a diff of a whole formatted repository is thousands of issues, of which a handful are on code the pull request touched, and the summary would list all of them.

So the input is renamed to `onlyNew` and applied once, up front. Everything downstream receives the same filtered list, the diff is fetched at most once, and the input is parsed once.

**This is a breaking change in two ways**, which is why it is `feat!` — though the classification is yours to make:

- `failOnlyNew` no longer exists. GitHub does not reject a `with:` key the action never declared, but it is not silent about it either: the runner emits an `Unexpected input(s) 'failOnlyNew', valid inputs are [...]` warning annotation that names `onlyNew` among the valid set (`actions/runner`, `ActionRunner.cs`). The input is still dropped, so `onlyNew` falls back to its `false` default and the run considers every issue — with `fail` defaulting to `true`, a stale workflow fails on the whole corpus rather than quietly narrowing.
- With `onlyNew` set, the SARIF now contains only the new issues. Uploading it to code scanning therefore **resolves the alerts of the unchanged code**, which is the opposite of what a repository-wide scan wants. The README says so next to the input, and the fix is to leave `onlyNew` unset on the scanning run.

`addComments` keeps its own two guards regardless of `onlyNew`, since a comment still cannot be anchored outside the pull request's diff.

### Migrating off the old name

A workflow left on `failOnlyNew` does not fail open — `addComments` keeps its own guards, so the comments stay correct. It fails *closed*: `failOnIssues` no longer filters anything, so the step fails on every pre-existing issue, and a repository-wide formatter check turns every pull request red, including ones touching none of the linted files. Loud rather than silent, which is the better of the two, but the message says `found 8238 issues` and so points the reader at their code rather than at their workflow.

The rename cannot be guarded in either direction anyway. A version that predates `onlyNew` ignores it in silence and fails on every issue, and no code in this PR can reach that consumer. So the README says to move the pin and rename the input in the same commit, which is the only instruction that covers both halves.

## `fix: decode a pull request diff returned as a buffer`

Found by a consuming session while building a mock of the GitHub API, and then measured against the real one rather than left as a hypothetical. **This one is pre-existing and shipped — the same code is in `v4.0.0` — but it is in here because the breaking commit above makes its consequence considerably worse.**

Octokit reads a response as text only when the content type matches `/^text\/|charset=utf-8$/`. That is case-sensitive and end-anchored:

| content type | routed as |
| --- | --- |
| `application/vnd.github.v3.diff; charset=utf-8` | text |
| `application/vnd.github.v3.diff; charset=UTF-8` | **buffer** |
| `application/vnd.github.v3.diff; charset=utf-8; boundary=x` | **buffer** |
| `application/vnd.github.v3.diff` | **buffer** |

GitHub currently sends the lowercase spelling, so this is latent rather than live — but `UTF-8` is the RFC-canonical casing, and any trailing parameter defeats the anchor too. `getPrDiff` cast the result straight to a string with `as unknown as string`, which is what let it through the type checker.

The consequence is total and silent. `parseDiff` on a cast `ArrayBuffer` returns **zero files**, with no error, so every issue fails `isNewIssue` and is dropped with only a `debug` line. Measured on a real 5,010-file repository by the consuming session, varying nothing but the header:

```
charset=utf-8  ->  exit 1, 50 comments, 7724 issues reported
charset=UTF-8  ->  exit 0, 0 comments, 0 errors, 0 warnings
```

A pull request with 7,724 genuine findings passes clean.

**Why it belongs in this PR rather than a follow-up.** At `v4.0.0` the SARIF is generated and written *before the diff is fetched at all* — `generateSarif` runs on the unfiltered issues, and `getPrDiff` is not called until several lines later. A transport failure there cannot reach the SARIF; it loses the comments and, with `failOnlyNew`, the failure. The `onlyNew` commit moves filtering ahead of `generateSarif`, so the same transport failure now produces an **empty** SARIF.

To be precise about the consequence, since it is easy to overstate: bugalint only *writes* that file, and only when `sarif` is set — it never uploads to code scanning itself. For a consumer that wires the file into `upload-sarif`, an empty SARIF resolves alerts that are still genuinely present. For a consumer that does not, the loss is confined to comments and the failure. Either way my change converts a silent drop into something strictly worse, so the guard against it is coupled to this branch rather than incidental to it.

The two failure directions are worth separating, because they are not equally bad:

| configuration | effect of a diff that parses to nothing |
| --- | --- |
| `comment` only | comments silently vanish, but every issue still reaches `failOnIssues`, so the job still goes **red** |
| `onlyNew` (or `failOnlyNew` before it) | issues filter to empty, so the job **fails open** — a green check over a broken tree |

A consuming session confirmed this against a real repository on both `v2.3.0` and `v4.0.0`, whose bundles carry the identical guard at the identical line: `comment: true` alone is enough to reach the bug.

Decoding the buffer removes the failure rather than reporting it, so no warning is needed in the normal case, and a response that is neither text nor bytes throws instead of matching every issue against nothing. The decode is extracted so it is unit-tested, since `getPrDiff` itself needs the API.

## `fix: fail on a pull request diff that cannot be parsed`

Decoding fixes the failure that was measured, but it can only guarantee that the bytes became a string, not that the string is a diff. A proxy or gateway answering with an HTML error page still parses to zero files, and the outcome is the one above: every issue treated as not being part of the pull request, no comment, green step. Note that `text/html; charset=utf-8` matches the `^text/` clause, so this case decodes perfectly and the decode cannot catch it.

The reason to validate the outcome instead of tightening the content type check is that the header carries no signal a generic sniffer can use. `application/vnd.github.v3.diff` is a vendor media type, and the consuming session found that PowerShell's HTTP client classifies it as bytes **even with `charset=utf-8` present**, because it ignores the charset parameter entirely. Octokit's `charset=utf-8$` clause is what rescues the type rather than what breaks it. Making that regex case-insensitive or unanchored would close the two spellings in the table above and leave the class open; checking what came out of the parse closes the class.

Failing rather than warning is the part a consuming session measured and pushed back on — with a warning, a pull request carrying 7,724 genuine findings still passed, twice warned and green. They were right, and the reason is stronger than a preference about severity. One commit earlier, a response arriving as an *object* throws. A response arriving as *text that is not a diff* has precisely the same consequence, and would merely be logged. The same failure would be fatal or silent depending on nothing but the JavaScript type the response happened to have, which is not a distinction worth making.

Beyond consistency: where the diff decides which issues are new, it is not decoration but the filter. A diff that cannot be parsed leaves no basis for the statement "no new issues", so passing the step reports a conclusion that was never computed. Failing says "I could not check", which is true; warning says "I checked and it is clean", which is not.

A pull request that genuinely changes nothing sends an empty diff rather than an unparsable one, which is what keeps the check quiet in the legitimate case. Failing also collapses the duplicate report for free — the diff is parsed once to filter the issues and once to place the comments, so a warning fires twice per run and reads as two incidents.

## `ci: include the Jest checks in the required check group`

Unrelated to the feature, and separable if you would rather have it on its own — but it is the reason I would not trust this PR's own green checks without it.

The only status check required to merge is `Required Checks`, which aggregates the repository's other checks by matching their names against `GitHub Action.*`, `Check.*` and `.*[lL]int.*`. The job that runs the tests is named `Jest`, which matches none of the three, and `bugroup-checks` treats a check outside its list as one that was not scheduled to run — so it succeeds however the tests ended.

A pull request whose tests fail, or whose test file fails to compile and therefore runs no test at all, shows a single red check that nothing enforces, while the required check stays green and branch protection on `main` allows the merge. Adding `Jest.*` closes it; I checked that every matrix variant (`Jest (ubuntu-latest)` and friends) matches, and that `Auto-merge`, `Release` and the aggregating job itself still do not.

## Verified against a real repository

Everything above is pinned by fixtures, but the branch has also been run end to end by a consuming session over a 5,010 file C++ tree, against the real output of `clang-format -i`. Reporting it because the interesting numbers are the ones that did *not* move.

| | before the blank line fix | after it | |
|---|---|---|---|
| results | 8,238 | 8,238 | unchanged |
| files | 743 | 743 | unchanged |
| fix is empty, i.e. delete | 423 | 372 | −51 |
| fix is a single empty line, i.e. blank | 0 | 51 | +51 |
| files containing a blanked line | 36 | 36 | unchanged |

The decomposition is the proof rather than the totals: exactly 51 results moved from the deletion bucket to the blanking bucket, the 372 genuine deletions stayed deletions, and no result appeared, vanished or changed anchor. Alongside it, on the same sweep: no end-of-file marker text reached a suggestion, no fix contained a carriage return, and all 8,238 emitted regions used the terminator-inclusive spelling. The blank-line defect was then confirmed on a throwaway pull request against that repository, on a comment this action itself posted in diff mode: the stored body is a fence, an empty line and a fence, and GitHub drew zero addition rows, while the two neighbouring comments in the same request drew three and one.

Two things were measured there rather than assumed. The terminator-only case is a **no-op on that repository** — 0 of 8,238 results came back without a fix, which is what an LF-only tree should give, but it is now measured, so it cannot regress them. And the summary bound turned out to be worth knowing: the *unfiltered* summary for all 8,238 issues is 0.99 MB against GitHub's 1 MiB cap, about 126 bytes per issue, so that repository was within one percent of losing its summary entirely. Filtering up front is what puts it back in reach, which is a benefit of the breaking commit I had not expected to be able to point at.

One limit of that repository as a witness, since it is the one consumer this was measured on: it exercises the 50-comment cap rarely. Issues per file run p50 4, p90 24, p99 126, max 463, so 26 of 743 files individually exceed the cap while holding 34% of all issues. When it does fire, only the comments truncate — `failOnIssues` still receives the complete filtered list, so the verdict and its count are never capped, only the view.

## Testing

- `sariffix` fixture pair plus a CI matrix entry, covering a single line fix, a multi line fix, a deletion, a fix containing a fence, a result with no fix, a region including the line terminator, a replacement ending in an empty line, a blanked line, a part-of-a-line fix and a fix pointing at the wrong lines. The blanked line sits next to the deletion on purpose: they are the pair the string representation could not tell apart, so the fixture fails if it ever regresses.
- `diff` fixture pair plus a CI matrix entry, covering a single line replacement, a multi line replacement, a pure deletion, an insertion in the middle of a file, an insertion at the top of a file, a replacement containing a fence, a blanked line, a file that does not end with a newline, a file whose only change is that missing terminator, and a blanked line with no neighbouring line to extend to.
- `diffcrlf` fixture pair plus a CI matrix entry, covering a diff of CRLF content end to end. The unit tests reach `parseFormatDiff` directly, so nothing covered the one line in `index.ts` that decides not to strip carriage returns for this format — it reads like a redundant special case, and deleting it silently rewrites the line endings of every suggestion. Removing it now changes that fixture's output. The fixture is marked `-text`, since normalizing it on commit would turn it into an ordinary diff and make it pass either way, which is the same class of invisible failure.
- Unit tests on the comment body (empty suggestion, preserved trailing empty line, fence growing), on the region handling (both spellings, both trailing-empty-line cases, both ignored cases) and on the diff format (old side anchoring, both insertion directions, the end-of-file marker, and carriage returns as content versus as terminators).
- The guard that stops a lone-newline fix rendering as a deletion is covered from the SARIF side specifically, since the diff path can no longer produce that shape and the guard would otherwise read as dead code to anyone reasoning from the diff path alone. Mutation-tested: removing it fails two tests, and the second names the input that gets it wrong.
- Updated the `isNewIssue` tests, added `isCommentableIssue` ones, and replaced the `failOnIssues` diff tests with direct `filterNewIssues` ones.
- The `pylintonlynew` CI matrix entry has its own fixture pair, since its output is filtered to nothing — previously it reused `pylint`'s input against `noissues`' expectation through an extra matrix key, which made the entry's expected output depend on a key rather than on its own name.
- `npx eslint .`, `npx jest` (54 passing) and `npm run package` are all clean at every commit on the branch, not only at the head, and every fixture round-trips through the SARIF parser unchanged.

Draft on purpose — please leave it as a draft until the consuming PR has been verified end to end against it.